### PR TITLE
(many) Moved console app to separate Perlang.ConsoleApp project

### DIFF
--- a/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Perlang.Interpreter\Perlang.Interpreter.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Perlang.ConsoleApp/Program.cs
+++ b/Perlang.ConsoleApp/Program.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using Perlang.Interpreter;
 using Perlang.Parser;
 
-namespace Perlang.Interpreter
+namespace Perlang.ConsoleApp
 {
     public class Program
     {

--- a/Perlang.Interpreter/Perlang.Interpreter.csproj
+++ b/Perlang.Interpreter/Perlang.Interpreter.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>

--- a/Perlang.Interpreter/RuntimeError.cs
+++ b/Perlang.Interpreter/RuntimeError.cs
@@ -4,7 +4,7 @@ namespace Perlang.Interpreter
 {
     public class RuntimeError : Exception
     {
-        internal Token Token { get; }
+        public Token Token { get; }
 
         internal RuntimeError(Token token, string message)
             : base(message)

--- a/Perlang.Interpreter/examples/ch9_calculate_fibonacci_sequence.lox
+++ b/Perlang.Interpreter/examples/ch9_calculate_fibonacci_sequence.lox
@@ -1,0 +1,9 @@
+var a = 0;
+var b = 1;
+
+while (a < 10000) {
+  print a;
+  var temp = a;
+  a = b;
+  b = temp + b;
+}

--- a/Perlang.sln
+++ b/Perlang.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Parser", "Perlang.P
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Tests", "Perlang.Tests\Perlang.Tests.csproj", "{1874E267-5D6F-4EA4-8938-F2A0D19F27B1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.ConsoleApp", "Perlang.ConsoleApp\Perlang.ConsoleApp.csproj", "{EC950B39-0187-41BD-A9AA-FE18F73BD30F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{1874E267-5D6F-4EA4-8938-F2A0D19F27B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1874E267-5D6F-4EA4-8938-F2A0D19F27B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1874E267-5D6F-4EA4-8938-F2A0D19F27B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC950B39-0187-41BD-A9AA-FE18F73BD30F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC950B39-0187-41BD-A9AA-FE18F73BD30F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC950B39-0187-41BD-A9AA-FE18F73BD30F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC950B39-0187-41BD-A9AA-FE18F73BD30F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
It feels unreasonable to place the console application inside the actual interpreter project. While it is slightly simpler that way, it means that for e.g. embedding scenarios we are forcing consumers to reference a project that already includes an application of itself. When we start adding more dependencies that are specific to the ConsoleApp, this will make even more sense.