### PR TITLE
(consoleapp) Add very basic ReadLine support

### DIFF
--- a/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -9,4 +9,8 @@
       <ProjectReference Include="..\Perlang.Interpreter\Perlang.Interpreter.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="ReadLine" Version="2.0.1" />
+    </ItemGroup>
+
 </Project>

--- a/Perlang.Parser/Scanner.cs
+++ b/Perlang.Parser/Scanner.cs
@@ -6,7 +6,7 @@ namespace Perlang.Parser
 {
     public class Scanner
     {
-        private static readonly IDictionary<string, TokenType> ReservedKeywords =
+        public static readonly IDictionary<string, TokenType> ReservedKeywords =
             new Dictionary<string, TokenType>
             {
                 {"and", AND},

--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Perlang/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=REPL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Xunit/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
We now support command history, and incredibly naïve auto-completion of Perlang reserved words. The latter is completely void of contextual grammar; in other words, it will suggest keywords that aren't
syntactically valid at the cursor location. So it's fairly useless, but it's still... a start.