### PR TITLE
(tests) Add `for`-tests

### DIFF
--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -12,10 +12,19 @@ namespace Perlang.Interpreter
         private readonly IDictionary<Expr, int> locals = new Dictionary<Expr, int>();
 
         private PerlangEnvironment perlangEnvironment;
+        private Action<string> standardOutputHandler;
 
-        public PerlangInterpreter(Action<RuntimeError> runtimeErrorHandler)
+        /// <summary>
+        /// Creates a new Perlang interpreter instance.
+        /// </summary>
+        /// <param name="runtimeErrorHandler"></param>
+        /// <param name="standardOutputHandler">an optional parameter that will receive output printed to
+        /// standard output. If not provided or null, output will be printed to the standard output of the
+        /// running process</param>
+        public PerlangInterpreter(Action<RuntimeError> runtimeErrorHandler, Action<string> standardOutputHandler = null)
         {
             this.runtimeErrorHandler = runtimeErrorHandler;
+            this.standardOutputHandler = standardOutputHandler ?? Console.WriteLine;
 
             perlangEnvironment = globals;
 
@@ -359,7 +368,7 @@ namespace Perlang.Interpreter
         public VoidObject VisitPrintStmt(Stmt.Print stmt)
         {
             object value = Evaluate(stmt.Expression);
-            Console.WriteLine(Stringify(value));
+            standardOutputHandler(Stringify(value));
             return null;
         }
 

--- a/Perlang.Tests/EvalHelper.cs
+++ b/Perlang.Tests/EvalHelper.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text;
 using Perlang.Interpreter;
 using Perlang.Parser;
 
@@ -40,6 +41,23 @@ namespace Perlang.Tests
                 AssertFailResolveErrorHandler);
 
             return result;
+        }
+
+        /// <summary>
+        /// Evaluates the provided expression or list of statements. If the expression or statements prints to the
+        /// standard output, the content will be returned.
+        /// </summary>
+        /// <param name="source">a valid Perlang programs</param>
+        /// <returns>the output from the provided expression/statements.</returns>
+        internal static IEnumerable<string> EvalReturningOutput(string source)
+        {
+            var output = new List<string>();
+
+            var interpreter = new PerlangInterpreter(AssertFailRuntimeErrorHandler, s => output.Add(s));
+            interpreter.Eval(source, AssertFailScanErrorHandler, AssertFailParseErrorHandler,
+                AssertFailResolveErrorHandler);
+
+            return output;
         }
 
         private static void AssertFailScanErrorHandler(ScanError scanError)

--- a/Perlang.Tests/For/Syntax.cs
+++ b/Perlang.Tests/For/Syntax.cs
@@ -1,0 +1,129 @@
+using Xunit;
+using static Perlang.Tests.EvalHelper;
+
+namespace Perlang.Tests.For
+{
+    // Tests based on https://github.com/munificent/craftinginterpreters/blob/master/test/for/syntax.lox
+    public class Syntax
+    {
+        [Fact]
+        public void single_expression_body()
+        {
+            var output = EvalReturningOutput("for (var c = 0; c < 3;) print c = c + 1;");
+
+            Assert.Equal(new[]
+            {
+                "1",
+                "2",
+                "3"
+            }, output);
+        }
+
+        [Fact(Skip = "Broken because of https://github.com/perlun/perlang/issues/12")]
+        public void block_body()
+        {
+            string source = @"
+                for (var a = 0; a < 3; a = a + 1) {
+                  print a;
+                }
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "0",
+                "1",
+                "2"
+            }, output);
+        }
+
+        [Fact]
+        public void no_clauses()
+        {
+            string source = @"
+                fun foo() {
+                  for (;;) return ""done"";
+                }
+                print foo();
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[] {"done"}, output);
+        }
+
+        [Fact]
+        public void no_variable()
+        {
+            string source = @"
+                var i = 0;
+                for (; i < 2; i = i + 1) print i;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "0",
+                "1",
+            }, output);
+        }
+
+        [Fact(Skip = "Broken because of https://github.com/perlun/perlang/issues/12")]
+        public void no_condition()
+        {
+            string source = @"
+                fun bar() {
+                  for (var i = 0;; i = i + 1) {
+                    print i;
+                    if (i >= 2) return;
+                  }
+                }
+                bar();
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "0",
+                "1",
+                "2"
+            }, output);
+        }
+
+        [Fact(Skip = "Broken because of https://github.com/perlun/perlang/issues/12")]
+        void no_increment()
+        {
+            string source = @"
+                for (var i = 0; i < 2;) {
+                  print i;
+                  i = i + 1;
+                }
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "0",
+                "1",
+            }, output);
+        }
+
+        [Fact]
+        void statement_bodies()
+        {
+            string source = @"
+                for (; false;) if (true) 1; else 2;
+                for (; false;) while (true) 1;
+                for (; false;) for (;;) 1;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new string[] {}, output);
+        }
+    }
+}

--- a/Perlang.Tests/Precedence.cs
+++ b/Perlang.Tests/Precedence.cs
@@ -3,6 +3,7 @@ using static Perlang.Tests.EvalHelper;
 
 namespace Perlang.Tests
 {
+    // Based on https://github.com/munificent/craftinginterpreters/blob/master/test/precedence.lox
     public class Precedence
     {
         [Fact]


### PR DESCRIPTION
This also included some changes to the interpreter to be able to capture the output from `print` statements. This is really nice, since it makes adding the full Lox test suite much simpler (which is something that I will probably do, a small chunk at a time, for the relevant parts).