### PR TITLE
(interpreter) Fix variable resolution in for loops

### DIFF
--- a/Perlang.Interpreter/Extensions/DictionaryExtensions.cs
+++ b/Perlang.Interpreter/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace Perlang.Interpreter.Extensions
+{
+    public static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Returns a value from a dictionary, returning <see cref="defaultValue"/> (defaults to null) if the key
+        /// cannot be found
+        ///
+        /// This method only works for value types/structs.
+        /// </summary>
+        /// <param name="dictionary">the dictionary</param>
+        /// <param name="key">the key</param>
+        /// <param name="defaultValue">the default value</param>
+        /// <typeparam name="T">the type of values in the dictionary</typeparam>
+        /// <returns>the value from the dictionary, or defaultValue if the key is not found</returns>
+        internal static T? TryGetStructValue<T>(this IDictionary<string, T> dictionary, string key,
+            T? defaultValue = null) where T : struct
+        {
+            return dictionary.TryGetValue(key, out T value) ? value : defaultValue;
+        }
+
+        /// <summary>
+        /// Returns a value from a dictionary, returning <see cref="defaultValue"/> (defaults to null) if the key
+        /// cannot be found
+        ///
+        /// This method is mostly suited for reference types. It can still be used with value types, but
+        /// <see cref="defaultValue"/> cannot be null in those cases.
+        /// </summary>
+        /// <param name="dictionary">the dictionary</param>
+        /// <param name="key">the key</param>
+        /// <param name="defaultValue">the default value</param>
+        /// <typeparam name="T">the type of values in the dictionary</typeparam>
+        /// <returns>the value from the dictionary, or defaultValue if the key is not found</returns>
+        internal static T TryGetObjectValue<T>(this IDictionary<string, T> dictionary, string key, T defaultValue = default)
+        {
+            return dictionary.TryGetValue(key, out T value) ? value : defaultValue;
+        }
+    }
+}

--- a/Perlang.Interpreter/PerlangEnvironment.cs
+++ b/Perlang.Interpreter/PerlangEnvironment.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Perlang.Interpreter.Extensions;
 
 namespace Perlang.Interpreter
 {
@@ -23,7 +24,7 @@ namespace Perlang.Interpreter
 
         internal object GetAt(int distance, string name)
         {
-            return Ancestor(distance).values[name];
+            return Ancestor(distance).values.TryGetObjectValue(name);
         }
 
         internal void AssignAt(int distance, Token name, object value)

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -12,7 +12,7 @@ namespace Perlang.Interpreter
         private readonly IDictionary<Expr, int> locals = new Dictionary<Expr, int>();
 
         private PerlangEnvironment perlangEnvironment;
-        private Action<string> standardOutputHandler;
+        private readonly Action<string> standardOutputHandler;
 
         /// <summary>
         /// Creates a new Perlang interpreter instance.

--- a/Perlang.Tests/For/Syntax.cs
+++ b/Perlang.Tests/For/Syntax.cs
@@ -19,7 +19,7 @@ namespace Perlang.Tests.For
             }, output);
         }
 
-        [Fact(Skip = "Broken because of https://github.com/perlun/perlang/issues/12")]
+        [Fact]
         public void block_body()
         {
             string source = @"
@@ -70,7 +70,7 @@ namespace Perlang.Tests.For
             }, output);
         }
 
-        [Fact(Skip = "Broken because of https://github.com/perlun/perlang/issues/12")]
+        [Fact]
         public void no_condition()
         {
             string source = @"
@@ -93,8 +93,8 @@ namespace Perlang.Tests.For
             }, output);
         }
 
-        [Fact(Skip = "Broken because of https://github.com/perlun/perlang/issues/12")]
-        void no_increment()
+        [Fact]
+        public void no_increment()
         {
             string source = @"
                 for (var i = 0; i < 2;) {
@@ -113,7 +113,7 @@ namespace Perlang.Tests.For
         }
 
         [Fact]
-        void statement_bodies()
+        public void statement_bodies()
         {
             string source = @"
                 for (; false;) if (true) 1; else 2;


### PR DESCRIPTION
The core problem here was that the `Stack` classes in Java and .NET seem to work differently. One grows upwards, the other grows downwards. This meant that the logic that this code used broke, since it relied on the Java-style semantics. (it was written in Java initially, remember?)

I fixed this by replacing it with a proper `List` instead, which is also much more performant on .NET than peeking in the middle of a stack. The code is arguably a bit more ugly though, so we could add a few helper methods/create our own `Stack` implementation at some point if we feel like cleaning things up a bit.

Fixes #12