### PR TITLE
(all) Add support for postfix increment and decrement

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -18,7 +18,8 @@ namespace Perlang
             TR VisitGroupingExpr(Grouping expr);
             TR VisitLiteralExpr(Literal expr);
             TR VisitLogicalExpr(Logical expr);
-            TR VisitUnaryExpr(Unary expr);
+            TR VisitUnaryPrefixExpr(UnaryPrefix expr);
+            TR VisitUnaryPostfixExpr(UnaryPostfix expr);
             TR VisitVariableExpr(Variable expr);
         }
 
@@ -132,19 +133,37 @@ namespace Perlang
             }
         }
 
-        public class Unary : Expr
+        public class UnaryPrefix : Expr
         {
             public Token Operator { get; }
             public Expr Right { get; }
 
-            public Unary(Token _operator, Expr right) {
+            public UnaryPrefix(Token _operator, Expr right) {
                 Operator = _operator;
                 Right = right;
             }
 
             public override TR Accept<TR>(IVisitor<TR> visitor)
             {
-                return visitor.VisitUnaryExpr(this);
+                return visitor.VisitUnaryPrefixExpr(this);
+            }
+        }
+
+        public class UnaryPostfix : Expr
+        {
+            public Expr Left { get; }
+            public Token Name { get; }
+            public Token Operator { get; }
+
+            public UnaryPostfix(Expr left, Token name, Token _operator) {
+                Left = left;
+                Name = name;
+                Operator = _operator;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitUnaryPostfixExpr(this);
             }
         }
 

--- a/Perlang.Common/TokenType.cs
+++ b/Perlang.Common/TokenType.cs
@@ -11,6 +11,7 @@ namespace Perlang
         EQUAL, EQUAL_EQUAL,
         GREATER, GREATER_EQUAL,
         LESS, LESS_EQUAL,
+        PLUS_PLUS, MINUS_MINUS,
 
         // Literals.
         IDENTIFIER, STRING, NUMBER,

--- a/Perlang.Common/Utils.cs
+++ b/Perlang.Common/Utils.cs
@@ -1,0 +1,29 @@
+namespace Perlang
+{
+    /// <summary>
+    /// Various utility methods
+    /// </summary>
+    public class Utils
+    {
+        public static string Stringify(object _object)
+        {
+            if (_object == null)
+            {
+                return "nil";
+            }
+
+            return _object.ToString();
+        }
+
+        public static string StringifyType(object _object)
+        {
+            if (_object == null)
+            {
+                return "nil";
+            }
+
+            return _object.GetType().Name;
+        }
+
+    }
+}

--- a/Perlang.Interpreter/Resolver.cs
+++ b/Perlang.Interpreter/Resolver.cs
@@ -137,11 +137,20 @@ namespace Perlang.Interpreter
             return null;
         }
 
-        public VoidObject VisitUnaryExpr(Expr.Unary expr)
+        public VoidObject VisitUnaryPrefixExpr(Expr.UnaryPrefix expr)
         {
             Resolve(expr.Right);
 
             return null;
+        }
+
+        public VoidObject VisitUnaryPostfixExpr(Expr.UnaryPostfix expr)
+        {
+            Resolve(expr.Left);
+            ResolveLocal(expr, expr.Name);
+
+            return null;
+
         }
 
         public VoidObject VisitVariableExpr(Expr.Variable expr)

--- a/Perlang.Parser/Scanner.cs
+++ b/Perlang.Parser/Scanner.cs
@@ -79,10 +79,10 @@ namespace Perlang.Parser
                     AddToken(DOT);
                     break;
                 case '-':
-                    AddToken(MINUS);
+                    AddToken(Match('-') ? MINUS_MINUS : MINUS);
                     break;
                 case '+':
-                    AddToken(PLUS);
+                    AddToken(Match('+') ? PLUS_PLUS : PLUS);
                     break;
                 case ';':
                     AddToken(SEMICOLON);

--- a/Perlang.Tests/For/Syntax.cs
+++ b/Perlang.Tests/For/Syntax.cs
@@ -9,7 +9,12 @@ namespace Perlang.Tests.For
         [Fact]
         public void single_expression_body()
         {
-            var output = EvalReturningOutput("for (var c = 0; c < 3;) print c = c + 1;");
+            string source = @"
+                for (var c = 0; c < 3;)
+                    print c = c + 1;
+            ";
+
+            var output = EvalReturningOutput(source);
 
             Assert.Equal(new[]
             {
@@ -123,7 +128,7 @@ namespace Perlang.Tests.For
 
             var output = EvalReturningOutput(source);
 
-            Assert.Equal(new string[] {}, output);
+            Assert.Equal(new string[] { }, output);
         }
     }
 }

--- a/Perlang.Tests/Operator/PostfixDecrement.cs
+++ b/Perlang.Tests/Operator/PostfixDecrement.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.EvalHelper;
+
+namespace Perlang.Tests.Operator
+{
+    public class PostfixDecrement
+    {
+        [Fact]
+        public void decrementing_defined_variable()
+        {
+            string source = @"
+                var i = 0;
+                i--;
+                print i;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[] {"-1"}, output);
+        }
+
+        [Fact]
+        public void decrementing_undefined_variable_throws_expected_exception()
+        {
+            string source = @"
+                x--;
+            ";
+
+            var result = EvalWithRuntimeCatch(source);
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.Matches("Undefined variable 'x'", exception.Message);
+        }
+
+        [Fact]
+        public void decrementing_nil_throws_expected_exception()
+        {
+            string source = @"
+                var i = nil;
+                i--;
+            ";
+
+            var result = EvalWithRuntimeCatch(source);
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.Matches("can only be used to decrement numbers, not nil", exception.Message);
+        }
+
+        [Fact]
+        public void decrementing_string_throws_expected_exception()
+        {
+            string source = @"
+                var i = ""foo"";
+                i--;
+            ";
+
+            var result = EvalWithRuntimeCatch(source);
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.Matches("can only be used to decrement numbers, not String", exception.Message);
+        }
+
+        [Fact]
+        public void decrement_can_be_used_in_for_loops()
+        {
+            string source = @"
+                for (var c = 3; c > 0; c--)
+                    print c;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "3",
+                "2",
+                "1"
+            }, output);
+        }
+    }
+}

--- a/Perlang.Tests/Operator/PostfixIncrement.cs
+++ b/Perlang.Tests/Operator/PostfixIncrement.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.EvalHelper;
+
+namespace Perlang.Tests.Operator
+{
+    public class PostfixIncrement
+    {
+        [Fact]
+        public void incrementing_defined_variable()
+        {
+            string source = @"
+                var i = 0;
+                i++;
+                print i;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[] { "1" }, output);
+        }
+
+        [Fact]
+        public void incrementing_undefined_variable_throws_expected_exception()
+        {
+            string source = @"
+                x++;
+            ";
+
+            var result = EvalWithRuntimeCatch(source);
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.Matches("Undefined variable 'x'", exception.Message);
+        }
+
+        [Fact]
+        public void incrementing_nil_throws_expected_exception()
+        {
+            string source = @"
+                var i = nil;
+                i++;
+            ";
+
+            var result = EvalWithRuntimeCatch(source);
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.Matches("can only be used to increment numbers, not nil", exception.Message);
+        }
+
+        [Fact]
+        public void incrementing_string_throws_expected_exception()
+        {
+            string source = @"
+                var i = ""foo"";
+                i++;
+            ";
+
+            var result = EvalWithRuntimeCatch(source);
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.Matches("can only be used to increment numbers, not String", exception.Message);
+        }
+
+        [Fact]
+        public void increment_can_be_used_in_for_loops()
+        {
+            string source = @"
+                for (var c = 0; c < 3; c++)
+                    print c;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "0",
+                "1",
+                "2"
+            }, output);
+        }
+    }
+}

--- a/scripts/generate_ast_classes.rb
+++ b/scripts/generate_ast_classes.rb
@@ -153,9 +153,14 @@ define_ast(OUTPUT_DIR, "Expr", [
     Field.new('Token', '_operator'),
     Field.new('Expr', 'right')
   ]),
-  Type.new('Unary', [
+  Type.new('UnaryPrefix', [
     Field.new('Token', '_operator'),
     Field.new('Expr', 'right')
+  ]),
+  Type.new('UnaryPostfix', [
+    Field.new('Expr', 'left'),
+    Field.new('Token', 'name'),
+    Field.new('Token', '_operator')
   ]),
   Type.new('Variable', Field.new('Token', 'name'))
 ])


### PR DESCRIPTION
~This is not ready yet, will complete another day.~ Reasonably complete now.

Things currently missing:

- [x] Support for decrement also, not just increment
- [ ] _Ensure that we put this at a reasonable level of precedence. (The way I did it now was just a slightly lame approximation)_

  Maybe we can live with this as it is now after all. Right now I put it between "assignment" and "logical or". I would love to detect invalid usages such as `foo(c++)` which I consider very bad practice, but we can perhaps live without that at this stage. _Note_: even though these are postfix operators at the moment, they work like _prefix_ operators do in other languages. I.e. `var c = 0; some_function(c);` will use `1` as the value of the the parameter passed to the function.

  I tried to document this now in the syntax grammar, which is btw again heavily inspired by the Lox specification: #18.
- [x] Properly handle cases when the user tries to do things like `var a = "foo"; a++;` and similar folly. This is clearly an area where a static type checker would make things immensely much better; then interpreter/compiler in the future will then have to take much less precautions in ensuring that things are of the expected types all the time.
