### PR TITLE
(many) Move builtin 'clock' function to stdlib project

### DIFF
--- a/Perlang.Common/GlobalCallableAttribute.cs
+++ b/Perlang.Common/GlobalCallableAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Perlang
+{
+    /// <summary>
+    /// Annotates an <see cref="ICallable"/> for automatic registration in the global namespace.
+    /// </summary>
+    public class GlobalCallableAttribute : Attribute
+    {
+        public string Name { get; }
+
+        public GlobalCallableAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/Perlang.Common/ICallable.cs
+++ b/Perlang.Common/ICallable.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 
-namespace Perlang.Interpreter
+namespace Perlang
 {
-    internal interface ICallable
+    public interface ICallable
     {
         object Call(IInterpreter interpreter, List<object> arguments);
         int Arity();

--- a/Perlang.Common/IEnvironment.cs
+++ b/Perlang.Common/IEnvironment.cs
@@ -1,0 +1,9 @@
+namespace Perlang
+{
+    public interface IEnvironment
+    {
+        void Define(string name, object value);
+        object GetAt(int distance, string name);
+        void AssignAt(int distance, Token name, object value);
+    }
+}

--- a/Perlang.Common/IInterpreter.cs
+++ b/Perlang.Common/IInterpreter.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 
-namespace Perlang.Interpreter
+namespace Perlang
 {
     public interface IInterpreter
     {
-        void ExecuteBlock(IEnumerable<Stmt> statements, PerlangEnvironment blockEnvironment);
+        void ExecuteBlock(IEnumerable<Stmt> statements, IEnvironment blockEnvironment);
         void Resolve(Expr expr, int depth);
     }
 }

--- a/Perlang.Interpreter/PerlangEnvironment.cs
+++ b/Perlang.Interpreter/PerlangEnvironment.cs
@@ -6,28 +6,29 @@ namespace Perlang.Interpreter
     /// <summary>
     /// Holds information about the context for a static scope (functions and variable name bindings).
     /// </summary>
-    public class PerlangEnvironment
+    internal class PerlangEnvironment : IEnvironment
     {
         private readonly PerlangEnvironment enclosing;
 
         private readonly Dictionary<string, object> values = new Dictionary<string, object>();
 
-        public PerlangEnvironment(PerlangEnvironment enclosing = null)
+        public PerlangEnvironment(IEnvironment enclosing = null)
         {
-            this.enclosing = enclosing;
+            // Cast is safe as long as we are the sole implementation of the IEnvironment interface.
+            this.enclosing = (PerlangEnvironment)enclosing;
         }
 
-        internal void Define(string name, object value)
+        public void Define(string name, object value)
         {
             values[name] = value;
         }
 
-        internal object GetAt(int distance, string name)
+        public object GetAt(int distance, string name)
         {
             return Ancestor(distance).values.TryGetObjectValue(name);
         }
 
-        internal void AssignAt(int distance, Token name, object value)
+        public void AssignAt(int distance, Token name, object value)
         {
             Ancestor(distance).values[name.Lexeme] = value;
         }

--- a/Perlang.Interpreter/PerlangFunction.cs
+++ b/Perlang.Interpreter/PerlangFunction.cs
@@ -2,12 +2,15 @@ using System.Collections.Generic;
 
 namespace Perlang.Interpreter
 {
-    class PerlangFunction : ICallable
+    /// <summary>
+    /// Callable implementation for user-defined functions.
+    /// </summary>
+    internal class PerlangFunction : ICallable
     {
         private readonly Stmt.Function declaration;
-        private readonly PerlangEnvironment closure;
+        private readonly IEnvironment closure;
 
-        internal PerlangFunction(Stmt.Function declaration, PerlangEnvironment closure)
+        internal PerlangFunction(Stmt.Function declaration, IEnvironment closure)
         {
             this.declaration = declaration;
             this.closure = closure;

--- a/Perlang.Stdlib/Callables/ClockCallable.cs
+++ b/Perlang.Stdlib/Callables/ClockCallable.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace Perlang.Stdlib.Callables
+{
+    [GlobalCallable("clock")]
+    public class Clock : ICallable
+    {
+        public int Arity()
+        {
+            return 0;
+        }
+
+        public object Call(IInterpreter interpreter, List<object> arguments)
+        {
+            return new DateTimeOffset(DateTime.Now).ToUnixTimeMilliseconds() / 1000.0;
+        }
+
+        public override string ToString()
+        {
+            return "<native fn>";
+        }
+    }
+}

--- a/Perlang.Stdlib/Perlang.Stdlib.csproj
+++ b/Perlang.Stdlib/Perlang.Stdlib.csproj
@@ -2,13 +2,10 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Perlang.Common\Perlang.Common.csproj" />
-      <ProjectReference Include="..\Perlang.Parser\Perlang.Parser.csproj" />
-      <ProjectReference Include="..\Perlang.Stdlib\Perlang.Stdlib.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Perlang.Tests/Stdlib/ClockTests.cs
+++ b/Perlang.Tests/Stdlib/ClockTests.cs
@@ -1,0 +1,26 @@
+using Xunit;
+using static Perlang.Tests.EvalHelper;
+
+namespace Perlang.Tests.Stdlib
+{
+    public class ClockTests
+    {
+        [Fact]
+        public void clock_is_a_callable()
+        {
+            Assert.IsAssignableFrom<ICallable>(Eval("clock"));
+        }
+
+        [Fact]
+        public void clock_returns_a_double_value()
+        {
+            Assert.IsType<double>(Eval("clock()"));
+        }
+
+        [Fact]
+        public void clock_returns_a_value_greater_than_zero()
+        {
+            Assert.True((double) Eval("clock()") > 0);
+        }
+    }
+}

--- a/Perlang.sln
+++ b/Perlang.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Tests", "Perlang.Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.ConsoleApp", "Perlang.ConsoleApp\Perlang.ConsoleApp.csproj", "{EC950B39-0187-41BD-A9AA-FE18F73BD30F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Perlang.Stdlib", "Perlang.Stdlib\Perlang.Stdlib.csproj", "{20267530-E991-4936-BFDC-0C5A1EDE90E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,5 +38,9 @@ Global
 		{EC950B39-0187-41BD-A9AA-FE18F73BD30F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EC950B39-0187-41BD-A9AA-FE18F73BD30F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EC950B39-0187-41BD-A9AA-FE18F73BD30F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20267530-E991-4936-BFDC-0C5A1EDE90E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20267530-E991-4936-BFDC-0C5A1EDE90E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20267530-E991-4936-BFDC-0C5A1EDE90E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20267530-E991-4936-BFDC-0C5A1EDE90E7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Callables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Perlang/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=REPL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This is a refactor/restructuring PR that lays the foundation for some upcoming work, where we will add more builtin functions. Adding them all to the `Perlang.Interpreter` project _can_ of course be done, but it makes more sense to move it to a separate project.

This PR also adds a way to dynamically detect all defined `ICallable` implementations and make them available to your Perlang code - you just decorate them with the `GlobalCallableAttribute` and off we go. This has the nice side effect of decoupling the stdlib from the interpreter in a neat way; the interpreter never calls anything in the stdlib in a _direct_ way, only in an indirect way (using reflection).

A subsequent change could potentially be to add a way to detect user-defined assemblies with `ICallable` implementations and make them available to your Perlang code - this should not be too hard given the mechanics introduced in this PR. Supporting scenarios like this will be quite important, especially since the performance of Perlang programs is expected to be rather poor until we implement a proper IL compiler for our parsed AST.