### PR TITLE
(all) Add CI & config for publishing packages on each `master` commit

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: .NET Core build & test
 
 on: [push]
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,93 @@
+name: .NET Core publish packages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Get current timestamp
+      id: timestamp
+      run: echo "::set-output name=timestamp::$(date +'%Y%m%d%H%M')"
+
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+
+    #
+    # Build releases
+    #
+    - name: Build linux-x64 release
+      run: dotnet publish -c Release -r linux-x64 --self-contained true
+      working-directory: ./Perlang.ConsoleApp
+
+    - name: Build osx-x64 release
+      run: dotnet publish -c Release -r osx-x64 --self-contained true
+      working-directory: ./Perlang.ConsoleApp
+
+    - name: Build win-x64 release
+      run: dotnet publish -c Release -r win-x64 --self-contained true
+      working-directory: ./Perlang.ConsoleApp
+
+    #
+    # Create .tar.gz archives
+    #
+    - name: Create linux-x64 .tar.gz file
+      run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${{github.sha}}-linux-x64.tar.gz *
+      working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/publish
+
+    - name: Create osx-x64 .tar.gz file
+      run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${{github.sha}}-osx-x64.tar.gz *
+      working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/osx-x64/publish
+
+    - name: Create win-x64 .tar.gz file
+      run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${{github.sha}}-win-x64.tar.gz *
+      working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/publish
+
+    #
+    # Upload files to bintray
+    #
+    - name: Upload linux-x64 .tar.gz file to Bintray
+      uses: gbl08ma/github-action-upload-bintray@master
+      with:
+        file: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/perlang-${{steps.timestamp.outputs.timestamp}}-${{github.sha}}-linux-x64.tar.gz
+        api_user: ${{ secrets.BINTRAY_API_USER }}
+        api_key: ${{ secrets.BINTRAY_API_KEY }}
+        repository_user: perlang
+        repository: builds
+        package: perlang
+        version: build
+        publish: 1
+        calculate_metadata: false
+
+    - name: Upload osx-x64 .tar.gz file to Bintray
+      uses: gbl08ma/github-action-upload-bintray@master
+      with:
+        file: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/osx-x64/perlang-${{steps.timestamp.outputs.timestamp}}-${{github.sha}}-osx-x64.tar.gz
+        api_user: ${{ secrets.BINTRAY_API_USER }}
+        api_key: ${{ secrets.BINTRAY_API_KEY }}
+        repository_user: perlang
+        repository: builds
+        package: perlang
+        version: build
+        publish: 1
+        calculate_metadata: false
+
+    - name: Upload win-x64 .tar.gz file to Bintray
+      uses: gbl08ma/github-action-upload-bintray@master
+      with:
+        file: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/perlang-${{steps.timestamp.outputs.timestamp}}-${{github.sha}}-win-x64.tar.gz
+        api_user: ${{ secrets.BINTRAY_API_USER }}
+        api_key: ${{ secrets.BINTRAY_API_KEY }}
+        repository_user: perlang
+        repository: builds
+        package: perlang
+        version: build
+        publish: 1
+        calculate_metadata: false

--- a/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <PublishTrimmed>true</PublishTrimmed>
+        <AssemblyName>perlang</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The idea is to build & publish builds as plain `.tar.gz` archives for each of the following targets on each push to the `master` branch:

- `linux-x64`
- `osx-x64`
- `win-x64`

The builds are available here: https://dl.bintray.com/perlang/builds/

We will also (perhaps at a slightly later stage) publish proper `.deb` packages for Ubuntu 16.04+ and Debian 9+, since this makes it much easier to always get the latest updates to the Perlang tooling.