### PR TITLE
(all) Add base64_encode function

### DIFF
--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -551,11 +551,25 @@ namespace Perlang.Interpreter
 
             if (arguments.Count != function.Arity())
             {
-                throw new RuntimeError(expr.Paren, "Expected " + function.Arity() + " arguments but got " +
+                throw new RuntimeError(expr.Paren, "Expected " + function.Arity() + " argument(s) but got " +
                                                    arguments.Count + ".");
             }
 
-            return function.Call(this, arguments);
+            try
+            {
+                return function.Call(this, arguments);
+            }
+            catch (Exception e)
+            {
+                if (expr.Callee is Expr.Variable v)
+                {
+                    throw new RuntimeError(v.Name, $"{v.Name.Lexeme}: {e.Message}");
+                }
+                else
+                {
+                    throw new RuntimeError(expr.Paren, e.Message);
+                }
+            }
         }
     }
 }

--- a/Perlang.Stdlib/Stdlib/Callables/Base64EncodeCallable.cs
+++ b/Perlang.Stdlib/Stdlib/Callables/Base64EncodeCallable.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Perlang.Stdlib.Callables
+{
+    [GlobalCallable("base64_encode")]
+    public class Base64EncodeCallable : ICallable
+    {
+        public object Call(IInterpreter interpreter, List<object> arguments)
+        {
+            var plainTextBytes = Encoding.UTF8.GetBytes((string)arguments[0]);
+
+            return Convert.ToBase64String(plainTextBytes, Base64FormattingOptions.InsertLineBreaks);
+        }
+
+        public int Arity()
+        {
+            return 1;
+        }
+    }
+}

--- a/Perlang.Tests/Stdlib/ArgvTests.cs
+++ b/Perlang.Tests/Stdlib/ArgvTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Perlang.Exceptions;
+using Perlang.Interpreter;
 using Xunit;
 using static Perlang.Tests.EvalHelper;
 
@@ -15,19 +16,20 @@ namespace Perlang.Tests.Stdlib
         }
 
         [Fact]
-        void argv_pop_with_no_arguments_throws_the_expected_exception()
+        public void argv_pop_with_no_arguments_throws_the_expected_exception()
         {
-            Assert.Throws<IllegalStateException>(() => Eval("argv_pop()"));
+            // TODO: Should verify exception message also ("argv_pop: No arguments left")
+            Assert.Throws<RuntimeError>(() => Eval("argv_pop()"));
         }
 
         [Fact]
-        void argv_pop_with_one_argument_returns_the_expected_result()
+        public void argv_pop_with_one_argument_returns_the_expected_result()
         {
             Assert.Equal("arg1", EvalWithArguments("argv_pop()", "arg1"));
         }
 
         [Fact]
-        void argv_pop_with_multiple_arguments_returns_the_expected_result()
+        public void argv_pop_with_multiple_arguments_returns_the_expected_result()
         {
             var output = new List<string>();
 
@@ -37,9 +39,10 @@ namespace Perlang.Tests.Stdlib
         }
 
         [Fact]
-        void argv_pop_too_many_times_throws_the_expected_exception()
+        public void argv_pop_too_many_times_throws_the_expected_exception()
         {
-            Assert.Throws<IllegalStateException>(() => EvalWithArguments("argv_pop(); argv_pop();", "arg1"));
+            // TODO: Should verify exception message also ("argv_pop: No arguments left")
+            Assert.Throws<RuntimeError>(() => EvalWithArguments("argv_pop(); argv_pop();", "arg1"));
         }
     }
 }

--- a/Perlang.Tests/Stdlib/Base64EncodeTests.cs
+++ b/Perlang.Tests/Stdlib/Base64EncodeTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Text;
+using Perlang.Interpreter;
+using Xunit;
+using static Perlang.Tests.EvalHelper;
+
+namespace Perlang.Tests.Stdlib
+{
+    public class Base64EncodeTests
+    {
+        [Fact]
+        public void base64_encode_is_a_callable()
+        {
+            Assert.IsAssignableFrom<ICallable>(Eval("base64_encode"));
+        }
+
+        [Fact]
+        public void base64_encode_with_no_arguments_throws_the_expected_exception()
+        {
+            var result = EvalWithRuntimeCatch("base64_encode()");
+            var exception = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+            Assert.IsType<RuntimeError>(exception);
+            Assert.Contains("Expected 1 argument(s)", exception.Message);
+        }
+
+        [Fact]
+        public void base64_encode_with_a_string_argument_returns_the_expected_result()
+        {
+            Assert.Equal("aGVqIGhlag==", Eval("base64_encode(\"hej hej\")"));
+        }
+
+        [Fact]
+        public void base64_encode_with_a_long_string_argument_returns_the_expected_result()
+        {
+            var sb = new StringBuilder();
+
+            for (int i = 0; i < 4; i++)
+            {
+                sb.Append("hej hej, hemskt mycket hej");
+            }
+
+            // At the moment, all lines are wrapped at every 76 characters. We could consider to make this configurable,
+            // but it's awkward until we support method overloading.
+            Assert.Equal(
+                "aGVqIGhlaiwgaGVtc2t0IG15Y2tldCBoZWpoZWogaGVqLCBoZW1za3QgbXlja2V0IGhlamhlaiBo\r\n" +
+                "ZWosIGhlbXNrdCBteWNrZXQgaGVqaGVqIGhlaiwgaGVtc2t0IG15Y2tldCBoZWou",
+                Eval($"base64_encode(\"{sb}.\")")
+            );
+        }
+
+        [Fact]
+        public void base64_encode_with_a_numeric_argument_throws_the_expected_exception()
+        {
+            var result = EvalWithRuntimeCatch("base64_encode(123.45)");
+            var runtimeError = result.RuntimeErrors.First();
+
+            Assert.Single(result.RuntimeErrors);
+
+            Assert.Equal("base64_encode: Unable to cast object of type 'System.Double' to type 'System.String'.",
+                runtimeError.Message);
+        }
+    }
+}


### PR DESCRIPTION
`base64_decode` will follow shortly.

The unrelated `RuntimeError` -> `Exception` widening of runtime errors is needed so we can properly handle exceptions in 3rd party code, custom (native) functions etc. Thinking more about it, perhaps an even better way to handle this would be to let the interpreter method handling the callable catch `Exception` and propagate it as a `RuntimeError` instead. The big advantage of this would be that we can then get a proper line location included in the `RuntimeError`, which is much more helpful to users when debugging problems in their programs.

Holding back on merging this until I've investigated that route a bit.