### PR TITLE
(ci) Fix publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -24,7 +24,7 @@ jobs:
     # Build releases
     #
     - name: Build linux-x64 release
-      run: dotnet publish -c Release -r linux-x64 --self-contained true
+      run: dotnet publish -c Release -r linux-x64 --self-contained true /p:PublishReadyToRun=true
       working-directory: ./Perlang.ConsoleApp
 
     - name: Build osx-x64 release

--- a/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -4,7 +4,8 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <PublishTrimmed>true</PublishTrimmed>
-        <PublishReadyToRun>true</PublishReadyToRun>
+        <!-- PublishReadyToRun is set on command line since it cannot
+             run in cross-compilation scenarios -->
         <AssemblyName>perlang</AssemblyName>
     </PropertyGroup>
 


### PR DESCRIPTION
It turned out the approach taken in #27 was overly naïve; it's not currently possible to cross-compile R2R assemblies per documentation given here: https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-3-0#cross-platformarchitecture-restrictions

~The way we work around is to run each build & publish job on different platforms instead, i.e. build Windows on Windows, macOS on macOS etc.~ This didn't work _either_, since container actions are not available on Windows or macOS... Trying another approach now.

Fixes #28