### PR TITLE
(many) Detect bare expressions more cleanly

### DIFF
--- a/Perlang.Tests/Var/VarTests.cs
+++ b/Perlang.Tests/Var/VarTests.cs
@@ -366,10 +366,7 @@ namespace Perlang.Tests.Var
 
             Assert.Single(result.ParseErrors);
 
-            // TODO: This should work, but currently fails. Likely since we parse the provided program
-            // TODO: both as an expression and as a (set of) statement(s).
-            //Assert.Matches("Error at 'false': Expect variable name", exception.Message);
-            Assert.Matches("Expect expression", exception.Message);
+            Assert.Matches("Error at 'false': Expect variable name", exception.ToString());
         }
 
         [Fact]
@@ -419,10 +416,7 @@ namespace Perlang.Tests.Var
 
             Assert.Single(result.ParseErrors);
 
-            // TODO: Make the assertion below work.
-            //Assert.Matches("Error at 'nil': Expect variable name.", exception.Message);
-
-            Assert.Matches("Expect expression", exception.Message);
+            Assert.Matches("Error at 'nil': Expect variable name.", exception.ToString());
         }
 
         [Fact]
@@ -437,10 +431,7 @@ namespace Perlang.Tests.Var
 
             Assert.Single(result.ParseErrors);
 
-            // TODO: Make the assertion below work.
-            //Assert.Matches("Error at 'this': Expect variable name", exception.Message);
-
-            Assert.Matches("Expect expression", exception.Message);
+            Assert.Matches("Error at 'this': Expect variable name", exception.ToString());
         }
     }
 }


### PR DESCRIPTION
When I wrote the original code for this, I hadn't looked at the solution provided by @munificent in https://github.com/munificent/craftinginterpreters/blob/master/note/answers/chapter08_statements.md. Hence, my suggested approach was rather brute an anything but elegant. This was being manifest in e.g. the `var` tests not returning the expected exceptions; this was a side effect of the ugly "parse as
expression first, then list of statements"-approach. This is definitely a step in the right direction IMO.