### PR TITLE
(consoleapp) Add --version flag

### DIFF
--- a/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
+++ b/Perlang.ConsoleApp/Perlang.ConsoleApp.csproj
@@ -12,11 +12,18 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- Assemblies implicitly referenced via reflection must be listed here, to be included in the
+             trimmed result -->
+        <TrimmerRootAssembly Include="System.Runtime.Extensions" />
+    </ItemGroup>
+
+    <ItemGroup>
       <ProjectReference Include="..\Perlang.Interpreter\Perlang.Interpreter.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="ReadLine" Version="2.0.1" />
+        <PackageReference Include="ReadLine" Version="2.0.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20158.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The following command line options now work pretty much like expected:

```shell
$ perlang -h
perlang:
  The Perlang Interpreter

Usage:
  perlang [options] [<perlang>...]

Arguments:
  <perlang>

Options:
  --version         Show version information
  -?, -h, --help    Show help and usage information

$ perlang --version
0.1.0+4bcf0ac
```