### PR TITLE
(interpreter) Cleanup in Resolver/PerlangInterpreter coupling

### DIFF
--- a/Perlang.Common/IInterpreter.cs
+++ b/Perlang.Common/IInterpreter.cs
@@ -7,6 +7,5 @@ namespace Perlang
         List<string> Arguments { get; }
 
         void ExecuteBlock(IEnumerable<Stmt> statements, IEnvironment blockEnvironment);
-        void Resolve(Expr expr, int depth);
     }
 }

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -121,7 +121,7 @@ namespace Perlang.Interpreter
                 // evaluation - resolving variable and function names.
 
                 var resolveErrors = new ResolveErrors();
-                var resolver = new Resolver(this, resolveError => resolveErrors.Add(resolveError));
+                var resolver = new Resolver(AddLocal, resolveError => resolveErrors.Add(resolveError));
                 resolver.Resolve(statements);
 
                 if (!resolveErrors.Empty())
@@ -366,7 +366,7 @@ namespace Perlang.Interpreter
             stmt.Accept(this);
         }
 
-        public void Resolve(Expr expr, int depth)
+        private void AddLocal(Expr expr, int depth)
         {
             locals[expr] = depth;
         }


### PR DESCRIPTION
Passing `this` from one class to another feels like a quite obvious antipattern that we should try to avoid; hopefully, #35 will help us detect code like this at an even earlier stage than before. Anyway, while working on static type support I discovered this and concluded that it could be a reasonably easy thing to fix.