### PR TITLE
(all) Support integer literals, not just doubles

### DIFF
--- a/Perlang.Tests/Precedence.cs
+++ b/Perlang.Tests/Precedence.cs
@@ -9,25 +9,25 @@ namespace Perlang.Tests
         [Fact]
         public void multiply_has_higher_precedence_than_plus()
         {
-            Assert.Equal(14.0, Eval("2 + 3 * 4"));
+            Assert.Equal(14, Eval("2 + 3 * 4"));
         }
 
         [Fact]
         public void multiply_has_higher_precedence_than_minus()
         {
-            Assert.Equal(8.0, Eval("20 - 3 * 4"));
+            Assert.Equal(8, Eval("20 - 3 * 4"));
         }
 
         [Fact]
         public void divide_has_higher_precedence_than_plus()
         {
-            Assert.Equal(4.0, Eval("2 + 6 / 3"));
+            Assert.Equal(4, Eval("2 + 6 / 3"));
         }
 
         [Fact]
         public void divide_has_higher_precedence_than_minus()
         {
-            Assert.Equal(0.0, Eval("2 - 6 / 3"));
+            Assert.Equal(0, Eval("2 - 6 / 3"));
         }
 
         [Fact]
@@ -57,16 +57,16 @@ namespace Perlang.Tests
         [Fact]
         public void one_minus_one_is_not_space_sensitive()
         {
-            Assert.Equal(0.0, Eval("1 - 1"));
-            Assert.Equal(0.0, Eval("1 -1"));
-            Assert.Equal(0.0, Eval("1- 1"));
-            Assert.Equal(0.0, Eval("1-1"));
+            Assert.Equal(0, Eval("1 - 1"));
+            Assert.Equal(0, Eval("1 -1"));
+            Assert.Equal(0, Eval("1- 1"));
+            Assert.Equal(0, Eval("1-1"));
         }
 
         [Fact]
         public void parentheses_can_be_used_for_grouping()
         {
-            Assert.Equal(4.0, Eval("(2 * (6 - (2 + 2)))"));
+            Assert.Equal(4, Eval("(2 * (6 - (2 + 2)))"));
         }
     }
 }


### PR DESCRIPTION
I decided to use `dynamic` to implement this for now. It's the simplest way to not having to handle all various combinations of integer types manually.

Doing it like this made it quite easy in the end, it felt impossible just some day ago. :)

As for how to handle integer literals, I decided to with the same rules are C# applies for now.

> If the literal has no suffix, its type is the first of the following
> types in which its value can be represented: int, uint, long, ulong.

(quoting https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types)

The suffix stuff is not supported at the moment; we provide no way to explicitly specify neither `ulong`, `uint` or `double`. This will probably have to fixed at some point, but just supporting various integer types and `double` is probably a good start. (We could do the same for the floating point values btw, to coerce them into `float` if
the encountered floating point literal is small enough.)