### PR TITLE
    (many) Store the TypeReference in the Resolver

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -1,8 +1,3 @@
-//
-// AUTO-GENERATED FILE, DO NOT MODIFY!
-//
-// Instead, change the ./scripts/generate_ast_classes.rb script that generated this code.
-//
 using System.Collections.Generic;
 
 namespace Perlang
@@ -25,10 +20,6 @@ namespace Perlang
 
         public class Empty : Expr
         {
-
-            public Empty() {
-            }
-
             public override TR Accept<TR>(IVisitor<TR> visitor)
             {
                 return visitor.VisitEmptyExpr(this);

--- a/Perlang.Common/Stmt.cs
+++ b/Perlang.Common/Stmt.cs
@@ -54,11 +54,13 @@ namespace Perlang
             public Token Name { get; }
             public List<Token> Params { get; }
             public List<Stmt> Body { get; }
+            public TypeReference ReturnTypeReference { get; }
 
-            public Function(Token name, List<Token> _params, List<Stmt> body) {
+            public Function(Token name, List<Token> _params, List<Stmt> body, TypeReference returnTypeReference) {
                 Name = name;
                 Params = _params;
                 Body = body;
+                ReturnTypeReference = returnTypeReference;
             }
 
             public override TR Accept<TR>(IVisitor<TR> visitor)
@@ -119,10 +121,12 @@ namespace Perlang
         {
             public Token Name { get; }
             public Expr Initializer { get; }
+            public TypeReference TypeReference { get; }
 
-            public Var(Token name, Expr initializer) {
+            public Var(Token name, Expr initializer, TypeReference typeReference) {
                 Name = name;
                 Initializer = initializer;
+                TypeReference = typeReference;
             }
 
             public override TR Accept<TR>(IVisitor<TR> visitor)

--- a/Perlang.Common/TypeReference.cs
+++ b/Perlang.Common/TypeReference.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace Perlang
+{
+    /// <summary>
+    /// A type reference is a (potentially unresolved) reference to a Perlang type.
+    /// </summary>
+    public class TypeReference
+    {
+        /// <summary>
+        /// A "None" type reference, indicating that no type information is available. Note that this is different
+        /// from an unresolved type reference, which is the state of a TypeReference before type inference has taken
+        /// place.
+        /// </summary>
+        public static TypeReference None { get; } = new TypeReference(null);
+
+        private Type clrType;
+        public Token TypeSpecifier { get; }
+
+        public Type ClrType
+        {
+            get => clrType;
+            set
+            {
+                if (clrType != null)
+                {
+                    // Poor-man's fake immutability. The problem is that the CLR type isn't really known at
+                    // construction time of the TypeReference; it is therefore always null. It gets populated
+                    // at a later stage in the compilation. But, how do we mutate it? We must either allow this
+                    // property to have a setter, or discard the TypeReference altogether and create a new one.
+                    // If we go the latter route, we just postpone the problem though; e.g. Stmt.Var.TypeReference
+                    // is not mutable either. So we would have to replace the Stmt node altogether, and so forth,
+                    // essentially discarding the whole AST for each node being handled by the type resolver.
+                    //
+                    // This is of course completely absurd and unreasonable. It has been said that an AST is a good
+                    // example of where immutability doesn't fit that well into the picture, and the above explanation
+                    // is one of the reasons why.
+                    //
+                    // So: the best we can do is to ensure that once the property is mutated, it is at least only
+                    // ever mutated _once_. I wonder if that will work all the way or if there any other nice
+                    // gotchas to be discovered further along the road... :-)
+                    throw new ArgumentException("ClrType already set; property is read-only");
+                }
+
+                clrType = value;
+            }
+        }
+
+        /// <summary>
+        /// The type reference contains an explicit type specifier. If this is false, the user is perhaps intending for
+        /// the type to be inferred from the program context.
+        /// </summary>
+        public bool IsTypeSpecified => TypeSpecifier != null;
+
+        /// <summary>
+        /// The type reference has been successfully resolved to a (loaded) CLR type.
+        /// </summary>
+        public bool IsResolved => ClrType != null;
+
+        public TypeReference(Token typeSpecifier)
+        {
+            TypeSpecifier = typeSpecifier;
+        }
+
+        public override string ToString()
+        {
+            if (IsTypeSpecified)
+            {
+                return IsResolved ? $"Explicit: {ClrType}" : $"Explicit: {TypeSpecifier}";
+            }
+            else
+            {
+                return IsResolved ? $"Inferred: {ClrType}" : "Inferred, not yet resolved";
+            }
+        }
+    }
+}

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -230,7 +230,7 @@ namespace Perlang.Parser
             }
 
             Consume(SEMICOLON, "Expect ';' after variable declaration.");
-            return new Stmt.Var(name, initializer);
+            return new Stmt.Var(name, initializer, TypeReference.None);
         }
 
         private Stmt WhileStatement()
@@ -282,7 +282,7 @@ namespace Perlang.Parser
 
             Consume(LEFT_BRACE, "Expect '{' before " + kind + " body.");
             List<Stmt> body = Block();
-            return new Stmt.Function(name, parameters, body);
+            return new Stmt.Function(name, parameters, body, TypeReference.None);
         }
 
         private List<Stmt> Block()

--- a/scripts/generate_ast_classes.rb
+++ b/scripts/generate_ast_classes.rb
@@ -132,41 +132,12 @@ OUTPUT_DIR = 'Perlang.Common'
 # clash with C# reserved words.
 #
 
-# Expressions
-define_ast(OUTPUT_DIR, "Expr", [
-  Type.new('Empty'),
-  Type.new('Assign', Field.new('Token', 'name'), Field.new('Expr', 'value')),
-  Type.new('Binary', [
-    Field.new('Expr', 'left'),
-    Field.new('Token', '_operator'),
-    Field.new('Expr', 'right')
-  ]),
-  Type.new('Call', [
-    Field.new('Expr', 'callee'),
-    Field.new('Token', 'paren'),
-    Field.new('List<Expr>', 'arguments')
-  ]),
-  Type.new('Grouping', Field.new('Expr', 'expression')),
-  Type.new('Literal', Field.new('object', 'value')),
-  Type.new('Logical', [
-    Field.new('Expr', 'left'),
-    Field.new('Token', '_operator'),
-    Field.new('Expr', 'right')
-  ]),
-  Type.new('UnaryPrefix', [
-    Field.new('Token', '_operator'),
-    Field.new('Expr', 'right')
-  ]),
-  Type.new('UnaryPostfix', [
-    Field.new('Expr', 'left'),
-    Field.new('Token', 'name'),
-    Field.new('Token', '_operator')
-  ]),
-  Type.new('Variable', Field.new('Token', 'name'))
-])
+# Expressions used to be generated from this file, but as complexity
+# grew we outgrew a format that could easily be created by this script.
+# We maintain the Expr.cs file manually instead for now.
 
 # Statements
-define_ast(OUTPUT_DIR, "Stmt", [
+define_ast(OUTPUT_DIR, 'Stmt', [
   Type.new('Block', Field.new('List<Stmt>', 'statements')),
 
   # Silly name to avoid clash with the 'Expression' property that
@@ -176,7 +147,8 @@ define_ast(OUTPUT_DIR, "Stmt", [
   Type.new('Function', [
     Field.new('Token', 'name'),
     Field.new('List<Token>', '_params'),
-    Field.new('List<Stmt>', 'body')
+    Field.new('List<Stmt>', 'body'),
+    Field.new('TypeReference', 'returnTypeReference')
   ]),
   Type.new('If', [
     Field.new('Expr', 'condition'),
@@ -187,7 +159,8 @@ define_ast(OUTPUT_DIR, "Stmt", [
   Type.new('Return', Field.new('Token', 'keyword'), Field.new('Expr', 'value')),
   Type.new('Var', [
     Field.new('Token', 'name'),
-    Field.new('Expr', 'initializer')
+    Field.new('Expr', 'initializer'),
+    Field.new('TypeReference', 'typeReference')
   ]),
   Type.new('While', Field.new('Expr', 'condition'), Field.new('Stmt', 'body'))
 ])


### PR DESCRIPTION
This is a "preparational commit", aimed at making support for static typing simpler. Will hold off on merging this a while, until I see that it's actually useful in implementing that PR. (I have a WIP PR for that, but it will probably take a couple of weeks or so before it's in any shape near mergeability...)