### PR TITLE
(tests) Add 'binary expression as function parameter' test

### DIFF
--- a/Perlang.Tests/Function.cs
+++ b/Perlang.Tests/Function.cs
@@ -144,7 +144,21 @@ namespace Perlang.Tests
             string output = EvalReturningOutput(source).SingleOrDefault();
 
             Assert.Equal("21", output);
+        }
 
+        [Fact]
+        void function_can_receive_binary_expression_as_argument()
+        {
+            string source = @"
+                var a = 1;
+
+                fun f(i) { return (i / 1024); }
+                print f(a * 1024);
+            ";
+
+            string output = EvalReturningOutput(source).SingleOrDefault();
+
+            Assert.Equal("1", output);
         }
 
         // "Negative" tests, asserting that errors are handled in a deterministic way.


### PR DESCRIPTION
This test was originally done while working on #43, but I wanted to isolated it to a separate commit/PR to investigate a problem with it. Eventually, it turned out to be a typo in the test; the implementation was fine, it was just the test that was b0rken. :see_no_evil: 