### PR TITLE
(ci) #56 Update latest-build symlink on each build

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -54,7 +54,7 @@ jobs:
       working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/publish
 
     #
-    # Upload files to bintray
+    # Upload files to releases server via rsync
     #
     - name: Upload linux-x64 .tar.gz file to releases server
       uses: easingthemes/ssh-deploy@v2.1.1
@@ -66,7 +66,7 @@ jobs:
           REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
           TARGET: ${{ secrets.SSH_REMOTE_TARGET }}
 
-    - name: Upload osx-x64 .tar.gz file to releases server
+    - name: Upload osx-x64 .tar.gz file to build cloud
       uses: easingthemes/ssh-deploy@v2.1.1
       env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -85,3 +85,11 @@ jobs:
           REMOTE_HOST: ${{ secrets.SSH_REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
           TARGET: ${{ secrets.SSH_REMOTE_TARGET }}
+
+    - name: Update latest build symlink
+      uses: appleboy/ssh-action@v0.1.1
+      with:
+        host: ${{ secrets.SSH_REMOTE_HOST }}
+        username: ${{ secrets.SSH_REMOTE_USER }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        script: ${{ secrets.UPDATE_SYMLINK_CMD }}


### PR DESCRIPTION
#55 changed from uploading builds to Bintray, to scp-based `rsync`. This PR adds on top of that by also updating the latest-build symlink on each build.

Here are the URLs for the latest builds generated by this:

- https://builds.perlang.org/perlang-latest-linux-64.tar.gz
- https://builds.perlang.org/perlang-latest-osx-64.tar.gz
- https://builds.perlang.org/perlang-latest-win-64.tar.gz