### PR TITLE
(scripts) #56 Add perlang-install script

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,37 @@
+name: perlang-install
+
+on: [push]
+
+jobs:
+  install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-16.04
+          - ubuntu-18.04
+          - ubuntu-20.04
+          - macos-10.15
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run perlang-install script
+      run: ./scripts/perlang-install
+    - name: Output perlang version
+      run: $HOME/.perlang/nightly/bin/perlang --version
+
+  # Windows need special treatment, since the default shell for Windows with
+  # GitHub actions is Powershell. We do not want to change to 'bash' for the
+  # other platforms though, since we want to ensure that the installer works on
+  # any POSIX compliant shell.
+  install_windows:
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run perlang-install script
+      run: ./scripts/perlang-install
+      shell: bash
+    - name: Output perlang version
+      run: $HOME/.perlang/nightly/bin/perlang --version
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ You should now have a `perlang` executable. Run `make run` to run it. If you are
 ## License
 
 [MIT](LICENSE)
+
+[perlang-install](scripts/perlang-install) is originally based on [rustup-init](https://github.com/rust-lang/rustup/blob/master/rustup-init.sh), which is also licensed under the MIT license.

--- a/scripts/perlang-install
+++ b/scripts/perlang-install
@@ -1,0 +1,467 @@
+#!/bin/sh
+# shellcheck shell=dash
+
+# Perlang installer. This is a script that can be downloaded from the internet
+# to install Perlang. It just does platform detection, downloads the correct
+# build and unpacks it.
+#
+# Originally based on the rustup-init script:
+# https://github.com/rust-lang/rustup/blob/master/rustup-init.sh
+
+# It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local`
+# extension. Note: Most shells limit `local` to 1 var per line, contra bash.
+
+# Fail on undefined variables
+set -u
+
+# If PERLANG_BUILDS_ROOT is unset or empty, use a default
+PERLANG_BUILDS_ROOT="${PERLANG_BUILDS_ROOT:-https://builds.perlang.org}"
+
+usage() {
+    cat 1>&2 <<EOF
+perlang-install (76bbdfa 2020-06-09)
+The installer for the perlang compiler and runtime.
+
+USAGE:
+    perlang-install [FLAGS] [OPTIONS]
+FLAGS:
+    -f, --force             Disable confirmation prompt before overwriting files
+    -h, --help              Prints help information
+OPTIONS:
+        --default-toolchain <default-toolchain>    Choose a default toolchain to install.
+                                                   Currently supported: nightly (default).
+
+Issues with this installer can be reported at the following address:
+https://github.com/perlun/perlang/issues
+EOF
+}
+
+main() {
+    downloader --check
+    need_cmd uname
+    need_cmd mktemp
+    need_cmd mkdir
+    need_cmd rm
+    need_cmd rmdir
+    need_cmd tar
+
+    get_architecture || return 1
+    local _arch="$RETVAL"
+    assert_nz "$_arch" "arch"
+
+    local _dir
+    _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t perlang-install)"
+    local _file="${_dir}/perlang-build.tar.gz"
+
+    local _is_tty=false
+
+    ansi_escapes_are_valid=false
+
+    if [ -t 2 ]; then
+        _is_tty=true
+
+        if [ "${TERM+set}" = 'set' ]; then
+            case "$TERM" in
+                xterm*|rxvt*|urxvt*|linux*|vt*)
+                    ansi_escapes_are_valid=true
+                ;;
+            esac
+        fi
+    fi
+
+    local _force=false
+    local _toolchain=nightly
+
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -f|--force)
+                _force=true
+                ;;
+            --default-toolchain)
+                shift
+
+                if [ "$#" -le "0" ]; then
+                    usage
+                    exit 1
+                fi
+
+                _toolchain=$1
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case $_toolchain in
+        nightly)
+            _toolchain_slug=latest
+            ;;
+        *)
+            err "Unsupported toolchain: $_toolchain"
+            ;;
+    esac
+
+    info "downloading toolchain '$_toolchain' for ${_arch}"
+
+    local _url="${PERLANG_BUILDS_ROOT}/perlang-${_toolchain_slug}-${_arch}.tar.gz"
+
+    ensure mkdir -p "$_dir"
+    ensure downloader "$_url" "$_file" "$_arch"
+
+    local _target_dir=$HOME/.perlang/${_toolchain}/bin
+
+    if [ -d "${_target_dir}" ] && [ "${_force}" != "true" ]; then
+        err "Target directory ${_target_dir} already exists. Use --force to overwrite an existing installation."
+    fi
+
+    # Wipe the directory clean before unpacking. This will delete any local
+    # modifications, which is fine; the target directory should be considered
+    # "read-only" from a user point-of-view.
+    info "unpacking toolchain '${_toolchain}'" 1>&2
+
+    ensure rm -rf "$_target_dir"
+    ensure mkdir -p "$_target_dir"
+    ensure tar xzf "$_file" -C "$_target_dir"
+
+    local _retval=$?
+
+    ignore rm "$_file"
+    ignore rmdir "$_dir"
+
+    echo
+
+    if $ansi_escapes_are_valid; then
+        # We presume that the likeliness of Unicode emojis working is higher in
+        # case ANSI escape sequences are valid.
+        echo "🎉 \33[1mInstallation complete 🎉\33[0m"
+    else
+        echo "Installation complete"
+    fi
+
+    echo
+    echo 'The download and installation completed without errors. You might want to add'
+    echo 'the following to your ~/.profile, to put the perlang toolchain in your $PATH:'
+    echo
+    echo '    # Perlang support'
+    echo "    [[ -d \"\$HOME/.perlang/${_toolchain}/bin\" ]] && export PATH=\$PATH:\$HOME/.perlang/${_toolchain}/bin"
+    echo
+    echo 'Thanks for giving Perlang a try! We love to hear your feedback, both positive and'
+    echo 'negative comments are welcome. Use the issue tracker at the following address'
+    echo 'to get in touch with us:'
+    echo
+    echo '    https://github.com/perlun/perlang/issues'
+    echo
+
+    return "$_retval"
+}
+
+get_bitness() {
+    need_cmd head
+    # Architecture detection without dependencies beyond coreutils.
+    # ELF files start out "\x7fELF", and the following byte is
+    #   0x01 for 32-bit and
+    #   0x02 for 64-bit.
+    # The printf builtin on some shells like dash only supports octal
+    # escape sequences, so we use those.
+    local _current_exe_head
+    _current_exe_head=$(head -c 5 /proc/self/exe )
+    if [ "$_current_exe_head" = "$(printf '\177ELF\001')" ]; then
+        echo 32
+    elif [ "$_current_exe_head" = "$(printf '\177ELF\002')" ]; then
+        echo 64
+    else
+        err "unknown platform bitness"
+    fi
+}
+
+get_architecture() {
+    local _ostype _cputype _bitness _arch
+    _ostype="$(uname -s)"
+    _cputype="$(uname -m)"
+
+    if [ "$_ostype" = Linux ]; then
+        if [ "$(uname -o)" = Android ]; then
+            _ostype=Android
+        fi
+    fi
+
+    if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
+        # Darwin `uname -m` lies
+        if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+            _cputype=x86_64
+        fi
+    fi
+
+    case "$_ostype" in
+
+        Linux)
+            _ostype=linux
+            _bitness=$(get_bitness)
+            ;;
+
+        Darwin)
+            _ostype=osx
+            ;;
+
+        MINGW* | MSYS* | CYGWIN*)
+            _ostype=win
+            ;;
+
+        *)
+            err "unsupported OS type: $_ostype"
+            ;;
+
+    esac
+
+    case "$_cputype" in
+
+        x86_64 | x86-64 | x64 | amd64)
+            _cputype=x64
+            ;;
+
+        *)
+            err "unsupported CPU type: $_cputype"
+
+    esac
+
+    # Detect 64-bit linux with 32-bit userland
+    if [ "${_ostype}" = linux ] && [ "${_bitness}" -eq 32 ]; then
+        err "64-bit Linux with 32-bit userland unsupported"
+    fi
+
+    _arch="${_ostype}-${_cputype}"
+
+    RETVAL="$_arch"
+}
+
+info() {
+    if $ansi_escapes_are_valid; then
+        printf "\33[1minfo:\33[0m %s\n" "$1" 1>&2
+    else
+        printf 'info: %s\n' "$1" 1>&2
+    fi
+}
+
+err() {
+    if $ansi_escapes_are_valid; then
+        printf "\33[31;1merror:\33[0m %s\n" "$1" 1>&2
+    else
+        printf 'error: %s\n' "$1" 1>&2
+    fi
+
+    exit 1
+}
+
+need_cmd() {
+    if ! check_cmd "$1"; then
+        err "need '$1' (command not found)"
+    fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+assert_nz() {
+    if [ -z "$1" ]; then err "assert_nz $2"; fi
+}
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing
+# command.
+ensure() {
+    if ! "$@"; then err "command failed: $*"; fi
+}
+
+# This is just for indicating that commands' results are being
+# intentionally ignored. Usually, because it's being executed
+# as part of error handling.
+ignore() {
+    "$@"
+}
+
+# This wraps curl or wget. Try curl first, if not installed,
+# use wget instead.
+downloader() {
+    local _dld
+    local _ciphersuites
+
+    if check_cmd curl; then
+        _dld=curl
+    elif check_cmd wget; then
+        _dld=wget
+    else
+        _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ "$1" = --check ]; then
+        need_cmd "$_dld"
+    elif [ "$_dld" = curl ]; then
+        get_ciphersuites_for_curl
+        _ciphersuites="$RETVAL"
+
+        local _curlopts="--show-error --fail"
+
+        if [ "${_is_tty}" = "true" ]; then
+            _curlopts="${_curlopts} --progress-bar"
+        else
+            _curlopts="${_curlopts} --silent"
+        fi
+
+        if [ -n "$_ciphersuites" ]; then
+            curl --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" ${_curlopts} --location "$1" --output "$2"
+        else
+            echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
+            if ! check_help_for "$3" curl --proto --tlsv1.2; then
+                echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
+                curl ${_curlopts} --location "$1" --output "$2"
+            else
+                curl --proto '=https' --tlsv1.2 ${_curlopts} --location "$1" --output "$2"
+            fi
+        fi
+    elif [ "$_dld" = wget ]; then
+        get_ciphersuites_for_wget
+        _ciphersuites="$RETVAL"
+
+        if [ -n "$_ciphersuites" ]; then
+            wget --https-only --secure-protocol=TLSv1_2 --ciphers "$_ciphersuites" "$1" -O "$2"
+        else
+            echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
+            if ! check_help_for "$3" wget --https-only --secure-protocol; then
+                echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
+                wget "$1" -O "$2"
+            else
+                wget --https-only --secure-protocol=TLSv1_2 "$1" -O "$2"
+            fi
+        fi
+    else
+        err "Unknown downloader"   # should not reach here
+    fi
+}
+
+check_help_for() {
+    local _arch
+    local _cmd
+    local _arg
+    _arch="$1"
+    shift
+    _cmd="$1"
+    shift
+
+    case "$_arch" in
+
+        # If we're running on OS-X, older than 10.13, then we always
+        # fail to find these options to force fallback
+        *darwin*)
+        if check_cmd sw_vers; then
+            if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
+                # Older than 10.13
+                echo "Warning: Detected OS X platform older than 10.13"
+                return 1
+            fi
+        fi
+        ;;
+
+    esac
+
+    for _arg in "$@"; do
+        if ! "$_cmd" --help | grep -q -- "$_arg"; then
+            return 1
+        fi
+    done
+
+    true # not strictly needed
+}
+
+# Return cipher suite string specified by user, otherwise return strong TLS 1.2-1.3 cipher suites
+# if support by local tools is detected. Detection currently supports these curl backends:
+# GnuTLS and OpenSSL (possibly also LibreSSL and BoringSSL). Return value can be empty.
+get_ciphersuites_for_curl() {
+    if [ -n "${RUSTUP_TLS_CIPHERSUITES-}" ]; then
+        # user specified custom cipher suites, assume they know what they're doing
+        RETVAL="$RUSTUP_TLS_CIPHERSUITES"
+        return
+    fi
+
+    local _openssl_syntax="no"
+    local _gnutls_syntax="no"
+    local _backend_supported="yes"
+    if curl -V | grep -q ' OpenSSL/'; then
+        _openssl_syntax="yes"
+    elif curl -V | grep -iq ' LibreSSL/'; then
+        _openssl_syntax="yes"
+    elif curl -V | grep -iq ' BoringSSL/'; then
+        _openssl_syntax="yes"
+    elif curl -V | grep -iq ' GnuTLS/'; then
+        _gnutls_syntax="yes"
+    else
+        _backend_supported="no"
+    fi
+
+    local _args_supported="no"
+    if [ "$_backend_supported" = "yes" ]; then
+        # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
+        if check_help_for "notspecified" "curl" "--tlsv1.2" "--ciphers" "--proto"; then
+            _args_supported="yes"
+        fi
+    fi
+
+    local _cs=""
+    if [ "$_args_supported" = "yes" ]; then
+        if [ "$_openssl_syntax" = "yes" ]; then
+            _cs=$(get_strong_ciphersuites_for "openssl")
+        elif [ "$_gnutls_syntax" = "yes" ]; then
+            _cs=$(get_strong_ciphersuites_for "gnutls")
+        fi
+    fi
+
+    RETVAL="$_cs"
+}
+
+# Return cipher suite string specified by user, otherwise return strong TLS 1.2-1.3 cipher suites
+# if support by local tools is detected. Detection currently supports these wget backends:
+# GnuTLS and OpenSSL (possibly also LibreSSL and BoringSSL). Return value can be empty.
+get_ciphersuites_for_wget() {
+    if [ -n "${RUSTUP_TLS_CIPHERSUITES-}" ]; then
+        # user specified custom cipher suites, assume they know what they're doing
+        RETVAL="$RUSTUP_TLS_CIPHERSUITES"
+        return
+    fi
+
+    local _cs=""
+    if wget -V | grep -q '\-DHAVE_LIBSSL'; then
+        # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
+        if check_help_for "notspecified" "wget" "TLSv1_2" "--ciphers" "--https-only" "--secure-protocol"; then
+            _cs=$(get_strong_ciphersuites_for "openssl")
+        fi
+    elif wget -V | grep -q '\-DHAVE_LIBGNUTLS'; then
+        # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
+        if check_help_for "notspecified" "wget" "TLSv1_2" "--ciphers" "--https-only" "--secure-protocol"; then
+            _cs=$(get_strong_ciphersuites_for "gnutls")
+        fi
+    fi
+
+    RETVAL="$_cs"
+}
+
+# Return strong TLS 1.2-1.3 cipher suites in OpenSSL or GnuTLS syntax. TLS 1.2
+# excludes non-ECDHE and non-AEAD cipher suites. DHE is excluded due to bad
+# DH params often found on servers (see RFC 7919). Sequence matches or is
+# similar to Firefox 68 ESR with weak cipher suites disabled via about:config.
+# $1 must be openssl or gnutls.
+get_strong_ciphersuites_for() {
+    if [ "$1" = "openssl" ]; then
+        # OpenSSL is forgiving of unknown values, no problems with TLS 1.3 values on versions that don't support it yet.
+        echo "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+    elif [ "$1" = "gnutls" ]; then
+        # GnuTLS isn't forgiving of unknown values, so this may require a GnuTLS version that supports TLS 1.3 even if wget doesn't.
+        # Begin with SECURE128 (and higher) then remove/add to build cipher suites. Produces same 9 cipher suites as OpenSSL but in slightly different order.
+        echo "SECURE128:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS-ALL:-CIPHER-ALL:-MAC-ALL:-KX-ALL:+AEAD:+ECDHE-ECDSA:+ECDHE-RSA:+AES-128-GCM:+CHACHA20-POLY1305:+AES-256-GCM"
+    fi
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
Also adds CI runs for various platforms, to ensure that the install script actually works. For reference, the installer is tested on the following platforms this way:

- Ubuntu 16.04
- Ubuntu 18.04
- Ubuntu 20.04
- macOS 10.15
- Windows Server 2019

After the installation, we also run `perlang --version` which serves two purposes. First, it emits the version number of the current "nightly" build into the CI logs. Secondly, it also means that we do a basic check that the perlang binary can actually start and do something meaningful on the platform in question.

Closes #56.