### PR TITLE
(many) Fix OverflowException when dividing floating point values

### DIFF
--- a/Perlang.Interpreter/PerlangEnvironment.cs
+++ b/Perlang.Interpreter/PerlangEnvironment.cs
@@ -53,12 +53,7 @@ namespace Perlang.Interpreter
             }
 
             // Fall-back to the enclosing scope if the variable isn't found in the current scope.
-            if (enclosing != null)
-            {
-                return enclosing.Get(name);
-            }
-
-            return null;
+            return enclosing?.Get(name);
         }
 
         internal void Assign(Token name, object value)

--- a/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -422,7 +422,19 @@ namespace Perlang.Interpreter.Typing
                 }
             }
 
-            private static decimal? GetMaxValue(Type type)
+            /// <summary>
+            /// Returns the approximate max value for the given type.
+            ///
+            /// The "approximate" part is important to understand how to properly use this method. Do not_ use it in
+            /// case you need an exact value. It is only suited for "size comparisons", to determine which one of two
+            /// values that uses the "larger" type. For example, Double is larger than Single; Double is also larger
+            /// than Decimal (even though the latter has a higher level of precision). Because of this, an example
+            /// of types for which this method will return an approximate, inexact return value is Decimal.
+            /// </summary>
+            /// <param name="type">a Type</param>
+            /// <returns>the approximate max value for the given type</returns>
+            /// <exception cref="ArgumentOutOfRangeException">in case the given type is not supported by this method</exception>
+            private static double? GetMaxValue(Type type)
             {
                 switch (Type.GetTypeCode(type))
                 {
@@ -437,7 +449,7 @@ namespace Perlang.Interpreter.Typing
                         // relaxing this and supporting Ruby-like things, like '*' * 10 to produce '**********'. However,
                         // after having used Ruby for a long time, our conclusion is that such constructs are rarely used
                         // and even though they add a bit of elegance/syntactic sugar to the expressiveness of the
-                        // language, the added cost in terms of complexity might not be worth it.
+                        // language, the cost in terms of added complexity might not be worth it.
                         return null;
 
                     case TypeCode.SByte:
@@ -457,11 +469,12 @@ namespace Perlang.Interpreter.Typing
                     case TypeCode.UInt64:
                         return UInt64.MaxValue;
                     case TypeCode.Single:
-                        return Convert.ToDecimal(Single.MaxValue);
+                        return Single.MaxValue;
                     case TypeCode.Double:
-                        return Convert.ToDecimal(Double.MaxValue);
+                        return Double.MaxValue;
                     case TypeCode.Decimal:
-                        return Decimal.MaxValue;
+                        // Note: this will likely loose some precision.
+                        return Convert.ToDouble(Decimal.MaxValue);
                     default:
                         throw new ArgumentOutOfRangeException();
                 }

--- a/Perlang.Tests/Operator/Comparison.cs
+++ b/Perlang.Tests/Operator/Comparison.cs
@@ -8,7 +8,7 @@ namespace Perlang.Tests.Operator
     public class Comparison
     {
         //
-        // Tests for the < operator
+        // Tests for the < (less than) operator
         //
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Perlang.Tests.Operator
         }
 
         //
-        // Tests for the <= operator
+        // Tests for the <= (less than or equals) operator
         //
 
         [Fact]
@@ -94,7 +94,7 @@ namespace Perlang.Tests.Operator
         }
 
         //
-        // Tests for the > operator
+        // Tests for the > (greater than) operator
         //
 
         [Fact]
@@ -137,7 +137,7 @@ namespace Perlang.Tests.Operator
         }
 
         //
-        // Tests for the >= operator
+        // Tests for the >= (greater than or equals) operator
         //
         [Fact]
         public void greater_than_or_equals_smaller_is_false()

--- a/Perlang.Tests/Operator/Division.cs
+++ b/Perlang.Tests/Operator/Division.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.EvalHelper;
+
+namespace Perlang.Tests.Operator
+{
+    // Tests based on the following:
+    // https://github.com/munificent/craftinginterpreters/blob/c6da0e61e6072271de404464c34b51c2fdc39e59/test/operator/divide.lox
+    // https://github.com/munificent/craftinginterpreters/blob/c6da0e61e6072271de404464c34b51c2fdc39e59/test/operator/divide_nonnum_num.lox
+    // https://github.com/munificent/craftinginterpreters/blob/c6da0e61e6072271de404464c34b51c2fdc39e59/test/operator/divide_num_nonnum.lox
+    public class Division
+    {
+        //
+        // Tests for the / (division) operator
+        [Fact]
+        public void dividing_integers_returns_integer()
+        {
+            string source = @"
+                8 / 2
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(4, result);
+        }
+
+        [Fact]
+        public void dividing_decimals_returns_decimal()
+        {
+            string source = @"
+                24.68 / 12.34
+            ";
+
+            object result = Eval(source);
+
+            Assert.Equal(2.0, result);
+        }
+
+        [Fact]
+        public void dividing_non_number_with_number_throws_expected_error()
+        {
+            string source = @"
+                ""1"" / 1
+            ";
+
+            var result = EvalWithTypeValidationErrorCatch(source);
+            var exception = result.TypeValidationErrors.FirstOrDefault();
+
+            Assert.Single(result.TypeValidationErrors);
+            Assert.Matches("Invalid arguments to operator SLASH specified", exception.Message);
+        }
+
+        [Fact]
+        public void dividing_number_with_non_number_throws_expected_error()
+        {
+            string source = @"
+                1 / ""1""
+            ";
+
+            var result = EvalWithTypeValidationErrorCatch(source);
+            var exception = result.TypeValidationErrors.FirstOrDefault();
+
+            Assert.Single(result.TypeValidationErrors);
+            Assert.Matches("Invalid arguments to operator SLASH specified", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
Also added division unit tests, to have better coverage for these kinds of errors in the future.

Fixes #61