### PR TITLE
(many) First steps towards class support

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Perlang
 {
@@ -23,6 +24,7 @@ namespace Perlang
             TR VisitUnaryPrefixExpr(UnaryPrefix expr);
             TR VisitUnaryPostfixExpr(UnaryPostfix expr);
             TR VisitIdentifierExpr(Identifier expr);
+            TR VisitGetExpr(Get expr);
         }
 
         //
@@ -91,6 +93,10 @@ namespace Perlang
                     if (Callee is Identifier variable)
                     {
                         return variable.Name.Lexeme;
+                    }
+                    else if (Callee is Get get)
+                    {
+                        return get.Name.Lexeme;
                     }
                     else
                     {
@@ -233,6 +239,27 @@ namespace Perlang
 
             public override string ToString() =>
                 Name.Lexeme;
+        }
+
+        public class Get : Expr
+        {
+            public Expr Object { get; }
+            public Token Name { get; }
+
+            // TODO: Would be much nicer to have this be immutable, but there is no easy way to accomplish this, since
+            // TODO: the MethodInfo data isn't available at construction time.
+            public MethodInfo Method { get; set; }
+
+            public Get(Expr @object, Token name)
+            {
+                Object = @object;
+                Name = name;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitGetExpr(this);
+            }
         }
 
         public abstract TR Accept<TR>(IVisitor<TR> visitor);

--- a/Perlang.Common/PerlangClass.cs
+++ b/Perlang.Common/PerlangClass.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Perlang
+{
+    public class PerlangClass
+    {
+        public string Name { get; }
+        public List<Stmt.Function> Methods { get; }
+
+        public PerlangClass(string name, List<Stmt.Function> methods)
+        {
+            Name = name;
+            Methods = methods;
+        }
+
+        public override string ToString() =>
+            Name;
+    }
+}

--- a/Perlang.Common/Stmt.cs
+++ b/Perlang.Common/Stmt.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -8,6 +9,7 @@ namespace Perlang
         public interface IVisitor<TR>
         {
             TR VisitBlockStmt(Block stmt);
+            TR VisitClassStmt(Class stmt);
             TR VisitExpressionStmt(ExpressionStmt stmt);
             TR VisitFunctionStmt(Function stmt);
             TR VisitIfStmt(If stmt);
@@ -21,7 +23,8 @@ namespace Perlang
         {
             public List<Stmt> Statements { get; }
 
-            public Block(List<Stmt> statements) {
+            public Block(List<Stmt> statements)
+            {
                 Statements = statements;
             }
 
@@ -31,11 +34,29 @@ namespace Perlang
             }
         }
 
+        public class Class : Stmt
+        {
+            public Token Name { get; }
+            public List<Function> Methods { get; }
+
+            public Class(Token name, List<Function> methods)
+            {
+                Name = name;
+                Methods = methods;
+            }
+
+            public override TR Accept<TR>(IVisitor<TR> visitor)
+            {
+                return visitor.VisitClassStmt(this);
+            }
+        }
+
         public class ExpressionStmt : Stmt
         {
             public Expr Expression { get; }
 
-            public ExpressionStmt(Expr expression) {
+            public ExpressionStmt(Expr expression)
+            {
                 Expression = expression;
             }
 
@@ -52,7 +73,9 @@ namespace Perlang
             public ImmutableList<Stmt> Body { get; }
             public TypeReference ReturnTypeReference { get; }
 
-            public Function(Token name, IEnumerable<Parameter> parameters, IEnumerable<Stmt> body, TypeReference returnTypeReference) {
+            public Function(Token name, IEnumerable<Parameter> parameters, IEnumerable<Stmt> body,
+                TypeReference returnTypeReference)
+            {
                 Name = name;
                 Parameters = parameters.ToImmutableList();
                 Body = body.ToImmutableList();
@@ -77,7 +100,8 @@ namespace Perlang
             public Stmt ThenBranch { get; }
             public Stmt ElseBranch { get; }
 
-            public If(Expr condition, Stmt thenBranch, Stmt elseBranch) {
+            public If(Expr condition, Stmt thenBranch, Stmt elseBranch)
+            {
                 Condition = condition;
                 ThenBranch = thenBranch;
                 ElseBranch = elseBranch;
@@ -93,7 +117,8 @@ namespace Perlang
         {
             public Expr Expression { get; }
 
-            public Print(Expr expression) {
+            public Print(Expr expression)
+            {
                 Expression = expression;
             }
 
@@ -108,7 +133,8 @@ namespace Perlang
             public Token Keyword { get; }
             public Expr Value { get; }
 
-            public Return(Token keyword, Expr value) {
+            public Return(Token keyword, Expr value)
+            {
                 Keyword = keyword;
                 Value = value;
             }
@@ -127,7 +153,8 @@ namespace Perlang
 
             public bool HasInitializer => Initializer != null;
 
-            public Var(Token name, Expr initializer, TypeReference typeReference) {
+            public Var(Token name, Expr initializer, TypeReference typeReference)
+            {
                 Name = name;
                 Initializer = initializer;
                 TypeReference = typeReference;
@@ -156,7 +183,8 @@ namespace Perlang
             public Expr Condition { get; }
             public Stmt Body { get; }
 
-            public While(Expr condition, Stmt body) {
+            public While(Expr condition, Stmt body)
+            {
                 Condition = condition;
                 Body = body;
             }

--- a/Perlang.Common/VisitorBase.cs
+++ b/Perlang.Common/VisitorBase.cs
@@ -88,9 +88,28 @@ namespace Perlang
             return VoidObject.Void;
         }
 
+        public virtual VoidObject VisitGetExpr(Expr.Get expr)
+        {
+            Visit(expr.Object);
+
+            return VoidObject.Void;
+        }
+
         public virtual VoidObject VisitBlockStmt(Stmt.Block stmt)
         {
             Visit(stmt.Statements);
+
+            return VoidObject.Void;
+        }
+
+        public VoidObject VisitClassStmt(Stmt.Class stmt)
+        {
+            // TODO: visit fields also, once we have implemented support for them.
+
+            foreach (Stmt.Function method in stmt.Methods)
+            {
+                Visit(method);
+            }
 
             return VoidObject.Void;
         }

--- a/Perlang.Interpreter/External/Humanizer/InflectorExtensions.cs
+++ b/Perlang.Interpreter/External/Humanizer/InflectorExtensions.cs
@@ -1,0 +1,101 @@
+// Based on
+// https://github.com/Humanizr/Humanizer/blob/2e0920bd14d633a730d4bc3686529442ad64e9c0/src/Humanizer/InflectorExtensions.cs,
+// which is in turn based on the Inflector class from Inflector (https://github.com/srkirkland/Inflector)
+//
+// Methods which depends on other classes have been removed, since we don't need them at the moment.
+
+
+// The MIT License (MIT)
+
+// Copyright (c) 2013 Scott Kirkland
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Text.RegularExpressions;
+
+namespace Humanizer
+{
+    /// <summary>
+    /// Inflector extensions
+    /// </summary>
+    public static class InflectorExtensions
+    {
+        /// <summary>
+        /// By default, pascalize converts strings to UpperCamelCase also removing underscores
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Pascalize(this string input)
+        {
+            return Regex.Replace(input, "(?:^|_| +)(.)", match => match.Groups[1].Value.ToUpper());
+        }
+
+        /// <summary>
+        /// Same as Pascalize except that the first character is lower case
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Camelize(this string input)
+        {
+            var word = input.Pascalize();
+            return word.Length > 0 ? word.Substring(0, 1).ToLower() + word.Substring(1) : word;
+        }
+
+        /// <summary>
+        /// Separates the input words with underscore
+        /// </summary>
+        /// <param name="input">The string to be underscored</param>
+        /// <returns></returns>
+        public static string Underscore(this string input)
+        {
+            return Regex.Replace(
+                Regex.Replace(
+                    Regex.Replace(input, @"([\p{Lu}]+)([\p{Lu}][\p{Ll}])", "$1_$2"), @"([\p{Ll}\d])([\p{Lu}])", "$1_$2"), @"[-\s]", "_").ToLower();
+        }
+
+        /// <summary>
+        /// Replaces underscores with dashes in the string
+        /// </summary>
+        /// <param name="underscoredWord"></param>
+        /// <returns></returns>
+        public static string Dasherize(this string underscoredWord)
+        {
+            return underscoredWord.Replace('_', '-');
+        }
+
+        /// <summary>
+        /// Replaces underscores with hyphens in the string
+        /// </summary>
+        /// <param name="underscoredWord"></param>
+        /// <returns></returns>
+        public static string Hyphenate(this string underscoredWord)
+        {
+            return Dasherize(underscoredWord);
+        }
+
+        /// <summary>
+        /// Separates the input words with hyphens and all the words are converted to lowercase
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Kebaberize(this string input)
+        {
+            return Underscore(input).Dasherize();
+        }
+    }
+}

--- a/Perlang.Interpreter/Resolution/Binding.cs
+++ b/Perlang.Interpreter/Resolution/Binding.cs
@@ -1,10 +1,12 @@
+using System.Collections.Immutable;
+
 namespace Perlang.Interpreter.Resolution
 {
     /// <summary>
     /// Holds information about a binding.
     ///
     /// Different types of bindings (=subclasses) provide slightly different mechanisms to retrieve information about
-    /// the variable or function being bound to.
+    /// the variable, function or class being bound to.
     /// </summary>
     internal abstract class Binding
     {

--- a/Perlang.Interpreter/Resolution/ClassBinding.cs
+++ b/Perlang.Interpreter/Resolution/ClassBinding.cs
@@ -1,0 +1,17 @@
+namespace Perlang.Interpreter.Resolution
+{
+    /// <summary>
+    /// A ClassBinding is a binding to a Perlang class. Note that this is specifically not referring to an instance of
+    /// a class, but to the class itself.
+    /// </summary>
+    internal class ClassBinding : Binding
+    {
+        public PerlangClass PerlangClass { get; }
+
+        public ClassBinding(Expr referringExpr, PerlangClass perlangClass) :
+            base(new TypeReference(typeof(PerlangClass)), referringExpr)
+        {
+            PerlangClass = perlangClass;
+        }
+    }
+}

--- a/Perlang.Interpreter/Resolution/ClassBindingFactory.cs
+++ b/Perlang.Interpreter/Resolution/ClassBindingFactory.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Perlang.Interpreter.Resolution
+{
+    internal class ClassBindingFactory : IBindingFactory
+    {
+        private readonly PerlangClass perlangClass;
+
+        public ClassBindingFactory(PerlangClass perlangClass)
+        {
+            this.perlangClass = perlangClass ?? throw new ArgumentException("perlangClass cannot be null");
+        }
+
+        public Binding CreateBinding(int distance, Expr referringExpr)
+        {
+            return new ClassBinding(referringExpr, perlangClass);
+        }
+    }
+}

--- a/Perlang.Interpreter/Resolution/INamedParameterizedBinding.cs
+++ b/Perlang.Interpreter/Resolution/INamedParameterizedBinding.cs
@@ -1,0 +1,10 @@
+using System.Collections.Immutable;
+
+namespace Perlang.Interpreter.Resolution
+{
+    internal interface INamedParameterizedBinding
+    {
+        public string FunctionName { get; }
+        public ImmutableArray<Parameter> Parameters { get; }
+    }
+}

--- a/Perlang.Interpreter/Resolution/MethodBinding.cs
+++ b/Perlang.Interpreter/Resolution/MethodBinding.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+
+namespace Perlang.Interpreter.Resolution
+{
+    /// <summary>
+    /// A binding to a .NET <see cref="MethodInfo"/> object.
+    ///
+    /// The method being referred to here can be either a native .NET method, or (in the future when we support) a
+    /// native .NET method being defined from Perlang.
+    /// </summary>
+    internal class MethodBinding : Binding, INamedParameterizedBinding
+    {
+        public MethodInfo Method { get; }
+        public string FunctionName { get; }
+        public ImmutableArray<Parameter> Parameters { get; }
+
+        public MethodBinding(MethodInfo method, Expr referringExpr) :
+            base(null, referringExpr)
+        {
+            Method = method;
+            FunctionName = method.Name;
+
+            Parameters = method.GetParameters()
+                .Select(p => new Parameter(new TypeReference(p.ParameterType)))
+                .ToImmutableArray();
+        }
+    }
+}

--- a/Perlang.Interpreter/Resolution/NativeBinding.cs
+++ b/Perlang.Interpreter/Resolution/NativeBinding.cs
@@ -6,7 +6,13 @@ using System.Reflection;
 
 namespace Perlang.Interpreter.Resolution
 {
-    internal class NativeBinding : Binding
+    /// <summary>
+    /// A binding to a native (.NET) method.
+    ///
+    /// "Native" in this sense means that the method is native to the runtime in which it is being executed. It should
+    /// not be confused with machine-native, unmanaged code (i.e. code written in languages like C, C++, Rust or Go.)
+    /// </summary>
+    internal class NativeBinding : Binding, INamedParameterizedBinding
     {
         public MethodInfo Method { get; }
         public string FunctionName { get; }

--- a/Perlang.Interpreter/Resolution/Resolver.cs
+++ b/Perlang.Interpreter/Resolution/Resolver.cs
@@ -24,6 +24,7 @@ namespace Perlang.Interpreter.Resolution
 
         private readonly Action<Binding> addLocalExprCallback;
         private readonly Action<Binding> addGlobalExprCallback;
+        private readonly Action<string, PerlangClass> addGlobalClassCallback;
         private readonly ResolveErrorHandler resolveErrorHandler;
 
         /// <summary>
@@ -33,15 +34,19 @@ namespace Perlang.Interpreter.Resolution
         /// <param name="addLocalExprCallback">A callback used to add an expression to a local scope at a
         /// given depth away from the call site. One level of nesting = one extra level of depth.</param>
         /// <param name="addGlobalExprCallback">A callback used to add an expression to the global scope.</param>
+        /// <param name="addGlobalClassCallback">A callback used to add a global, top-level class.</param>
         /// <param name="resolveErrorHandler">A callback which will be called in case of resolution errors. Note that
         /// multiple resolution errors will cause the provided callback to be called multiple times.</param>
         internal Resolver(ImmutableDictionary<string, TypeReferenceNativeFunction> globalCallables,
             Action<Binding> addLocalExprCallback,
-            Action<Binding> addGlobalExprCallback, ResolveErrorHandler resolveErrorHandler)
+            Action<Binding> addGlobalExprCallback,
+            Action<string, PerlangClass> addGlobalClassCallback,
+            ResolveErrorHandler resolveErrorHandler)
         {
             this.globalCallables = globalCallables;
             this.addLocalExprCallback = addLocalExprCallback;
             this.addGlobalExprCallback = addGlobalExprCallback;
+            this.addGlobalClassCallback = addGlobalClassCallback;
             this.resolveErrorHandler = resolveErrorHandler;
         }
 
@@ -148,6 +153,18 @@ namespace Perlang.Interpreter.Resolution
             // function return type and function statement (in case of a function being defined). These details are
             // useful later on, in the static type analysis.
             scopes.Last()[name.Lexeme] = new FunctionBindingFactory(typeReference, function);
+        }
+
+        private void DefineClass(Token name, PerlangClass perlangClass)
+        {
+            if (globals.ContainsKey(name.Lexeme))
+            {
+                resolveErrorHandler(new ResolveError($"Class {name.Lexeme} already defined; cannot redefine", name));
+                return;
+            }
+
+            globals[name.Lexeme] = new ClassBindingFactory(perlangClass);
+            addGlobalClassCallback(name.Lexeme, perlangClass);
         }
 
         private void ResolveLocal(Expr referringExpr, Token name)
@@ -283,11 +300,33 @@ namespace Perlang.Interpreter.Resolution
             return VoidObject.Void;
         }
 
+        public VoidObject VisitGetExpr(Expr.Get expr)
+        {
+            Resolve(expr.Object);
+
+            return VoidObject.Void;
+        }
+
         public VoidObject VisitBlockStmt(Stmt.Block stmt)
         {
             BeginScope();
             Resolve(stmt.Statements);
             EndScope();
+
+            return VoidObject.Void;
+        }
+
+        public VoidObject VisitClassStmt(Stmt.Class stmt)
+        {
+            // TODO: Implement resolution related to classes: handle fields defined in the class, resolve method
+            // TODO: arguments, etc.
+
+            Declare(stmt.Name);
+
+            var perlangClass = new PerlangClass(stmt.Name.Lexeme, stmt.Methods);
+
+            DefineClass(stmt.Name, perlangClass);
+
             return VoidObject.Void;
         }
 

--- a/Perlang.Interpreter/TargetAndMethodContainer.cs
+++ b/Perlang.Interpreter/TargetAndMethodContainer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Reflection;
+
+namespace Perlang.Interpreter
+{
+    /// <summary>
+    /// Container class for a target object instance and a method.
+    ///
+    /// The object instance can be null, which is the correct state for representing method calls to static methods.
+    /// </summary>
+    public class TargetAndMethodContainer
+    {
+        public object Target { get; }
+        public MethodInfo Method { get; }
+
+        public TargetAndMethodContainer(object target, MethodInfo method)
+        {
+            Target = target;
+            Method = method;
+        }
+
+        public override string ToString()
+        {
+            if (Target != null)
+            {
+                // Slightly inspired by Ruby, where "Integer.method(:to_s)" returns "#<Method: Integer.to_s>"
+                return $"#<{Target} {Method}>";
+            }
+            else
+            {
+                return Method.ToString();
+            }
+        }
+    }
+}

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -102,6 +102,7 @@ namespace Perlang.Parser
         {
             try
             {
+                if (Match(CLASS)) return ClassDeclaration();
                 if (Match(FUN)) return Function("function");
                 if (Match(VAR)) return VarDeclaration();
 
@@ -269,6 +270,22 @@ namespace Perlang.Parser
             }
 
             return new Stmt.ExpressionStmt(expr);
+        }
+
+        private Stmt.Class ClassDeclaration()
+        {
+            Token name = Consume(IDENTIFIER, "Expect class name.");
+            Consume(LEFT_BRACE, "Expect '{' before class body.");
+
+            var methods = new List<Stmt.Function>();
+
+            while (!Check(RIGHT_BRACE) && !IsAtEnd()) {
+                methods.Add(Function("method"));
+            }
+
+            Consume(RIGHT_BRACE, "Expect '}' after class body.");
+
+            return new Stmt.Class(name, methods);
         }
 
         private Stmt.Function Function(string kind)
@@ -483,6 +500,11 @@ namespace Perlang.Parser
                 if (Match(LEFT_PAREN))
                 {
                     expr = FinishCall(expr);
+                }
+                else if (Match(DOT))
+                {
+                    Token name = Consume(IDENTIFIER, "Expect identifier after '.'.");
+                    expr = new Expr.Get(expr, name);
                 }
                 else
                 {

--- a/Perlang.Tests/Classes/ClassesTests.cs
+++ b/Perlang.Tests/Classes/ClassesTests.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using Xunit;
+using static Perlang.Tests.EvalHelper;
+
+namespace Perlang.Tests.Classes
+{
+    /// <summary>
+    /// Class-related tests
+    ///
+    /// Based on https://github.com/munificent/craftinginterpreters/tree/master/test/class
+    /// </summary>
+    public class ClassesTests
+    {
+        [Fact]
+        public void empty_class()
+        {
+            string source = @"
+                class Foo {}
+
+                print Foo;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "Foo",
+            }, output);
+        }
+
+        [Fact]
+        public void duplicate_class_name()
+        {
+            string source = @"
+                class Foo {}
+                class Foo {}
+            ";
+
+            var result = EvalWithResolveErrorCatch(source);
+            var exception = result.ResolveErrors.First();
+
+            Assert.Single(result.ResolveErrors);
+            Assert.Matches("Class Foo already defined; cannot redefine", exception.Message);
+        }
+
+        [Fact]
+        public void can_get_reference_to_static_method()
+        {
+            string source = @"
+                class Foo {}
+
+                print Foo.to_string;
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                // This comes straight out of the MethodInfo, so uses .NET-casing for now.
+                "#<Foo System.String ToString()>",
+            }, output);
+        }
+
+        [Fact]
+        public void can_call_static_method()
+        {
+            string source = @"
+                class Foo {}
+
+                print Foo.to_string();
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "Foo",
+            }, output);
+        }
+
+        [Fact] //(Skip = "Currently produces Perlang.Parser.ParseError: Expect ';' after value.")]
+        public void can_chain_method_calls_for_static_method()
+        {
+            string source = @"
+                class Foo {}
+
+                print Foo.to_string().to_string();
+            ";
+
+            var output = EvalReturningOutput(source);
+
+            Assert.Equal(new[]
+            {
+                "Foo",
+            }, output);
+        }
+    }
+}

--- a/Perlang.Tests/Number/NumberTests.cs
+++ b/Perlang.Tests/Number/NumberTests.cs
@@ -18,7 +18,7 @@ namespace Perlang.Tests.Number
             var exception = result.ParseErrors.FirstOrDefault();
 
             Assert.Single(result.ParseErrors);
-            Assert.Matches("Expect ';' after expression", exception.Message);
+            Assert.Matches("Expect identifier after '.'", exception.Message);
         }
 
         [Fact]

--- a/Perlang.Tests/Return.cs
+++ b/Perlang.Tests/Return.cs
@@ -87,7 +87,7 @@ namespace Perlang.Tests
             Assert.Equal("ok", output);
         }
 
-        [Fact(Skip = "Disabled until we have implemented support for classes")]
+        [Fact(Skip = "Blocked pending https://github.com/perlun/perlang/issues/66")]
         void in_method()
         {
             string source = @"

--- a/Perlang.Tests/Var/VarTests.cs
+++ b/Perlang.Tests/Var/VarTests.cs
@@ -135,7 +135,7 @@ namespace Perlang.Tests.Var
             }, output);
         }
 
-        [Fact(Skip = "Classes are not supported yet")]
+        [Fact(Skip = "Blocked pending https://github.com/perlun/perlang/issues/66")]
         public void local_from_method()
         {
             string source = @"

--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -1,5 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Callables/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pascalize/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=pascalized/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Perlang/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=REPL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Truthy/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This is still a bit WIP, working on #66, but opening it now since all tests are green.

### Implemented parts

- [x] Be able to define classes
- [x] Detect multiple classes with the same name, throw an exception if this happens
- [x] Support for calling static methods (only on native .NET classes at the moment)

### Remaining parts

- [ ] Support for calling static methods with parameters. (this one should be quite easy to fix)
- [ ] Support for instantiating classes.
- [ ] Support for calling methods on instances
- [ ] Support for fields and/or properties
- [ ] Support for defining static methods
- [ ] ...probably a bunch of other things as well
- [ ] Support for defining classes in "native" .NET code, and static methods on these.

For me, the last one of these is perhaps the most important. I would like the `base64_encode` and `base64_decode` top-level functions to be moved to a `Base64` class, and be `Base64.encode` and `Base64.decode`, or something like that. So I might focus on some fixes moving in that direction in the near future.