### PR TITLE
(many) Minor cleanup: renamed Expr.Variable to Expr.Identifier

### DIFF
--- a/Perlang.Common/Expr.cs
+++ b/Perlang.Common/Expr.cs
@@ -22,7 +22,7 @@ namespace Perlang
             TR VisitLogicalExpr(Logical expr);
             TR VisitUnaryPrefixExpr(UnaryPrefix expr);
             TR VisitUnaryPostfixExpr(UnaryPostfix expr);
-            TR VisitVariableExpr(Variable expr);
+            TR VisitIdentifierExpr(Identifier expr);
         }
 
         //
@@ -60,10 +60,10 @@ namespace Perlang
             public Token Operator { get; }
             public Expr Right { get; }
 
-            public Binary(Expr left, Token _operator, Expr right)
+            public Binary(Expr left, Token @operator, Expr right)
             {
                 Left = left;
-                Operator = _operator;
+                Operator = @operator;
                 Right = right;
             }
 
@@ -88,7 +88,7 @@ namespace Perlang
             {
                 get
                 {
-                    if (Callee is Variable variable)
+                    if (Callee is Identifier variable)
                     {
                         return variable.Name.Lexeme;
                     }
@@ -113,7 +113,7 @@ namespace Perlang
 
             public override string ToString()
             {
-                if (Callee is Variable variable)
+                if (Callee is Identifier variable)
                 {
                     return $"'call function {variable.Name.Lexeme}'";
                 }
@@ -165,10 +165,10 @@ namespace Perlang
             public Token Operator { get; }
             public Expr Right { get; }
 
-            public Logical(Expr left, Token _operator, Expr right)
+            public Logical(Expr left, Token @operator, Expr right)
             {
                 Left = left;
-                Operator = _operator;
+                Operator = @operator;
                 Right = right;
             }
 
@@ -183,9 +183,9 @@ namespace Perlang
             public Token Operator { get; }
             public Expr Right { get; }
 
-            public UnaryPrefix(Token _operator, Expr right)
+            public UnaryPrefix(Token @operator, Expr right)
             {
-                Operator = _operator;
+                Operator = @operator;
                 Right = right;
             }
 
@@ -201,11 +201,11 @@ namespace Perlang
             public Token Name { get; }
             public Token Operator { get; }
 
-            public UnaryPostfix(Expr left, Token name, Token _operator)
+            public UnaryPostfix(Expr left, Token name, Token @operator)
             {
                 Left = left;
                 Name = name;
-                Operator = _operator;
+                Operator = @operator;
             }
 
             public override TR Accept<TR>(IVisitor<TR> visitor)
@@ -214,18 +214,21 @@ namespace Perlang
             }
         }
 
-        public class Variable : Expr
+        /// <summary>
+        /// Represents an identifier, such as a variable name, a function name or a class.
+        /// </summary>
+        public class Identifier : Expr
         {
             public Token Name { get; }
 
-            public Variable(Token name)
+            public Identifier(Token name)
             {
                 Name = name;
             }
 
             public override TR Accept<TR>(IVisitor<TR> visitor)
             {
-                return visitor.VisitVariableExpr(this);
+                return visitor.VisitIdentifierExpr(this);
             }
 
             public override string ToString() =>

--- a/Perlang.Common/VisitorBase.cs
+++ b/Perlang.Common/VisitorBase.cs
@@ -81,9 +81,9 @@ namespace Perlang
         }
 
         /// <summary>
-        /// Need not be called in child classes.
+        /// Does not need to be called in child classes.
         /// </summary>
-        public virtual VoidObject VisitVariableExpr(Expr.Variable expr)
+        public virtual VoidObject VisitIdentifierExpr(Expr.Identifier expr)
         {
             return VoidObject.Void;
         }

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -353,7 +353,7 @@ namespace Perlang.Interpreter
             }
 
             dynamic previousValue = left;
-            var variable = (Expr.Variable) expr.Left;
+            var variable = (Expr.Identifier) expr.Left;
             object value;
 
             switch (expr.Operator.Type)
@@ -390,7 +390,7 @@ namespace Perlang.Interpreter
             return value;
         }
 
-        public object VisitVariableExpr(Expr.Variable expr)
+        public object VisitIdentifierExpr(Expr.Identifier expr)
         {
             return LookUpVariable(expr.Name, expr);
         }
@@ -765,9 +765,9 @@ namespace Perlang.Interpreter
                     }
                     catch (Exception e)
                     {
-                        if (expr.Callee is Expr.Variable v)
+                        if (expr.Callee is Expr.Identifier identifier)
                         {
-                            throw new RuntimeError(v.Name, $"{v.Name.Lexeme}: {e.Message}");
+                            throw new RuntimeError(identifier.Name, $"{identifier.Name.Lexeme}: {e.Message}");
                         }
                         else
                         {

--- a/Perlang.Interpreter/Resolution/Resolver.cs
+++ b/Perlang.Interpreter/Resolution/Resolver.cs
@@ -226,9 +226,9 @@ namespace Perlang.Interpreter.Resolution
                 Resolve(argument);
             }
 
-            if (expr.Callee is Expr.Variable variableExpr)
+            if (expr.Callee is Expr.Identifier identifierExpr)
             {
-                ResolveLocal(expr, variableExpr.Name);
+                ResolveLocal(expr, identifierExpr.Name);
             }
 
             return VoidObject.Void;
@@ -268,7 +268,7 @@ namespace Perlang.Interpreter.Resolution
             return VoidObject.Void;
         }
 
-        public VoidObject VisitVariableExpr(Expr.Variable expr)
+        public VoidObject VisitIdentifierExpr(Expr.Identifier expr)
         {
             // Note: providing the defaultValue in the TryGetObjectValue() call here is critical, since we must
             // be able to distinguish between "set to null" and "not set at all".

--- a/Perlang.Interpreter/Typing/TypeValidator.cs
+++ b/Perlang.Interpreter/Typing/TypeValidator.cs
@@ -244,10 +244,10 @@ namespace Perlang.Interpreter.Typing
                 }
                 catch (NameResolutionError)
                 {
-                    if (expr.Callee is Expr.Variable variable)
+                    if (expr.Callee is Expr.Identifier identifier)
                     {
-                        throw new NameResolutionError(variable.Name,
-                            $"Attempting to call undefined function '{variable.Name.Lexeme}'");
+                        throw new NameResolutionError(identifier.Name,
+                            $"Attempting to call undefined function '{identifier.Name.Lexeme}'");
                     }
                     else
                     {
@@ -315,7 +315,7 @@ namespace Perlang.Interpreter.Typing
                 return VoidObject.Void;
             }
 
-            public override VoidObject VisitVariableExpr(Expr.Variable expr)
+            public override VoidObject VisitIdentifierExpr(Expr.Identifier expr)
             {
                 TypeReference typeReference = getVariableOrFunctionCallback(expr)?.TypeReference;
 

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -336,9 +336,9 @@ namespace Perlang.Parser
                 Token equals = Previous();
                 Expr value = Assignment();
 
-                if (expr is Expr.Variable variable)
+                if (expr is Expr.Identifier identifier)
                 {
-                    Token name = variable.Name;
+                    Token name = identifier.Name;
                     return new Expr.Assign(name, value);
                 }
 
@@ -356,9 +356,9 @@ namespace Perlang.Parser
             {
                 Token increment = Previous();
 
-                if (expr is Expr.Variable variable)
+                if (expr is Expr.Identifier identifier)
                 {
-                    return new Expr.UnaryPostfix(variable, variable.Name, increment);
+                    return new Expr.UnaryPostfix(identifier, identifier.Name, increment);
                 }
 
                 Error(increment, $"Can only increment variables, not {StringifyType(expr)}.");
@@ -367,9 +367,9 @@ namespace Perlang.Parser
             {
                 Token decrement = Previous();
 
-                if (expr is Expr.Variable variable)
+                if (expr is Expr.Identifier identifier)
                 {
-                    return new Expr.UnaryPostfix(variable, variable.Name, decrement);
+                    return new Expr.UnaryPostfix(identifier, identifier.Name, decrement);
                 }
 
                 Error(decrement, $"Can only decrement variables, not {StringifyType(expr)}.");
@@ -528,7 +528,7 @@ namespace Perlang.Parser
 
             if (Match(IDENTIFIER))
             {
-                return new Expr.Variable(Previous());
+                return new Expr.Identifier(Previous());
             }
 
             if (Match(LEFT_PAREN))


### PR DESCRIPTION
I realized that it seemed incorrect to name this expression type "variable" now that it can refer to both variables, functions and
classes. I'm not 100% sure about this though, since there is also a _token_ named `IDENTIFIER` which is used when constructing `Get` expressions in a WIP PR I'm working on (#73), but time will whether this change is a good idea or not.