### PR TITLE
(stdlib) Fix Base64.decode support for non-padded strings

### DIFF
--- a/Perlang.Stdlib/Stdlib/Base64.cs
+++ b/Perlang.Stdlib/Stdlib/Base64.cs
@@ -15,6 +15,16 @@ namespace Perlang.Stdlib
 
         public static string Decode(string base64Data)
         {
+            // Convert.FromBase64String requires data to be padded. We relax this a bit, like many other programming
+            // languages (Ruby, PHP, Javascript) and do not require the padding to be present. It would be even more
+            // efficient to be able to tell Convert.FromBase64String() to ignore it, but this will do for now.
+            int numPaddingCharacters = base64Data.Length % 4;
+
+            if (numPaddingCharacters != 0)
+            {
+                base64Data += new string('=', 4 - numPaddingCharacters);
+            }
+
             var data = Convert.FromBase64String(base64Data);
 
             // For now, blindly assume that the base64-encoded data is a valid UTF-8/ASCII string and parse it as such.

--- a/Perlang.Tests.Integration/Stdlib/Base64DecodeTests.cs
+++ b/Perlang.Tests.Integration/Stdlib/Base64DecodeTests.cs
@@ -24,9 +24,16 @@ namespace Perlang.Tests.Integration.Stdlib
         }
 
         [Fact]
-        public void Base64_decode_with_a_string_argument_returns_the_expected_result()
+        public void Base64_decode_with_a_padded_string_argument_returns_the_expected_result()
         {
             Assert.Equal("hej hej", Eval("Base64.decode(\"aGVqIGhlag==\")"));
+        }
+
+        [Fact]
+        public void Base64_decode_with_an_non_padded_string_argument_returns_the_expected_result()
+        {
+            // This used to fail at one point, which is why we added a test for it.
+            Assert.Equal("hej hej", Eval("Base64.decode(\"aGVqIGhlag\")"));
         }
 
         [Fact]


### PR DESCRIPTION
This fixes #76.