### PR TITLE
(ci) Auto-publish website

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+    paths:
+      # TODO: Replace Perlang** with src/ once we have moved all the projects in there.
+      # TODO: https://github.com/perlun/perlang/issues/82
+      - Perlang**
 
 jobs:
   build:

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -1,0 +1,34 @@
+name: Publish website
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      # TODO: Replace Perlang** with src/ once we have moved all the projects in there.
+      # TODO: https://github.com/perlun/perlang/issues/82
+      - docs/**
+      - Perlang**
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Rebuild website
+      run: make docs
+
+    #
+    # Upload files to public web server via rsync
+    #
+    - name: Upload generated web site
+      uses: easingthemes/ssh-deploy@v2.1.1
+      env:
+          SSH_PRIVATE_KEY: ${{ secrets.WWW_SSH_PRIVATE_KEY }}
+          ARGS: "-rltgoDzvO"
+          SOURCE: "./_site/"
+          REMOTE_HOST: ${{ secrets.WWW_SSH_REMOTE_HOST }}
+          REMOTE_USER: ${{ secrets.WWW_SSH_REMOTE_USER }}
+          TARGET: ${{ secrets.WWW_SSH_REMOTE_TARGET }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,9 +1,15 @@
 name: Website
 
-on: [push]
+# No need to run this on master pushes since publish-website takes care of it
+# for that branch.
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The provided GitHub Action is now set up to publish updates whenever any relevant files are changed on the `master` branch. This should make it much more convenient to push changes to https://perlang.org than before; no more manual `rsync`ing from a developer laptop etc.