### PR TITLE
(many) Do not allow redeclaring globals

### DIFF
--- a/Perlang.Common/IEnvironment.cs
+++ b/Perlang.Common/IEnvironment.cs
@@ -2,7 +2,7 @@ namespace Perlang
 {
     public interface IEnvironment
     {
-        void Define(string name, object value);
+        void Define(Token name, object value);
         object GetAt(int distance, string name);
         void AssignAt(int distance, Token name, object value);
     }

--- a/Perlang.Common/RuntimeError.cs
+++ b/Perlang.Common/RuntimeError.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Perlang.Interpreter
+namespace Perlang
 {
     public class RuntimeError : Exception
     {

--- a/Perlang.Interpreter/PerlangEnvironment.cs
+++ b/Perlang.Interpreter/PerlangEnvironment.cs
@@ -18,9 +18,16 @@ namespace Perlang.Interpreter
             this.enclosing = (PerlangEnvironment)enclosing;
         }
 
-        public void Define(string name, object value)
+        public void Define(Token name, object value)
         {
-            values[name] = value;
+            if (values.ContainsKey(name.Lexeme))
+            {
+                throw new RuntimeError(name, "Variable with this name already declared in this scope.");
+            }
+            else
+            {
+                values[name.Lexeme] = value;
+            }
         }
 
         public object GetAt(int distance, string name)

--- a/Perlang.Interpreter/PerlangFunction.cs
+++ b/Perlang.Interpreter/PerlangFunction.cs
@@ -23,7 +23,7 @@ namespace Perlang.Interpreter
 
             for (int i = 0; i < declaration.Parameters.Count; i++)
             {
-                environment.Define(declaration.Parameters[i].Name.Lexeme, arguments[i]);
+                environment.Define(declaration.Parameters[i].Name, arguments[i]);
             }
 
             try

--- a/Perlang.Interpreter/PerlangInterpreter.cs
+++ b/Perlang.Interpreter/PerlangInterpreter.cs
@@ -651,7 +651,7 @@ namespace Perlang.Interpreter
 
         public VoidObject VisitClassStmt(Stmt.Class stmt)
         {
-            currentEnvironment.Define(stmt.Name.Lexeme, globalClasses[stmt.Name.Lexeme]);
+            currentEnvironment.Define(stmt.Name, globalClasses[stmt.Name.Lexeme]);
             return VoidObject.Void;
         }
 
@@ -664,7 +664,7 @@ namespace Perlang.Interpreter
         public VoidObject VisitFunctionStmt(Stmt.Function stmt)
         {
             var function = new PerlangFunction(stmt, currentEnvironment);
-            currentEnvironment.Define(stmt.Name.Lexeme, function);
+            currentEnvironment.Define(stmt.Name, function);
             return VoidObject.Void;
         }
 
@@ -706,7 +706,7 @@ namespace Perlang.Interpreter
                 value = Evaluate(stmt.Initializer);
             }
 
-            currentEnvironment.Define(stmt.Name.Lexeme, value);
+            currentEnvironment.Define(stmt.Name, value);
             return VoidObject.Void;
         }
 

--- a/Perlang.Stdlib/Exceptions/Exceptions.cs
+++ b/Perlang.Stdlib/Exceptions/Exceptions.cs
@@ -1,5 +1,3 @@
-using Perlang.Interpreter;
-
 namespace Perlang.Exceptions
 {
     /// <summary>


### PR DESCRIPTION
This has been something which was allowed historically; we inherited the semantics from Lox in this case and it was rediscovered now when working on #60. However, I've not been very fond of it. Yes, yes, Scheme allows it, Rust allows it, but we are neither Scheme nor Rust. C# disallows it, and I think a solid case for not supporting these semantics can be made.

Let's disallow it for now, we can always revisit this decision later if we discover this to be a great thing after all.