### PR TITLE
(docs) Include internal classes in published docs

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -27,7 +27,7 @@ jobs:
       uses: easingthemes/ssh-deploy@v2.1.1
       env:
           SSH_PRIVATE_KEY: ${{ secrets.WWW_SSH_PRIVATE_KEY }}
-          ARGS: "-rltgoDzvO"
+          ARGS: "-rlgoDzvO"
           SOURCE: "./_site/"
           REMOTE_HOST: ${{ secrets.WWW_SSH_REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.WWW_SSH_REMOTE_USER }}

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -13,8 +13,7 @@
             ],
             "dest": "api",
             "filter": "filter-config.yml",
-            "disableGitFeatures": false,
-            "disableDefaultFilter": false
+            "disableDefaultFilter": true
         }
     ],
 


### PR DESCRIPTION
Since a large part of our classes are internal, it doesn't make sense to have this enabled. The "API docs" are also the "Perlang internals docs", so it makes sense to be able to generate the full docs for all of it here.
