### PR TITLE
(ci) Run publish job for all pushes

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,12 +8,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.101
+
       - name: Re-generate auto-generated files
         run: make auto-generated
+
       - name: Build with dotnet
         run: dotnet build --configuration Release
 
@@ -22,11 +25,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.101
+
       - name: Re-generate auto-generated files
         run: make auto-generated
+
       - name: Run test suite
         run: dotnet test --configuration Release --verbosity normal

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -2,11 +2,10 @@ name: .NET Core publish packages
 
 on:
   push:
-    branches:
-      - master
     paths:
       # TODO: Replace Perlang** with src/ once we have moved all the projects in there.
       # TODO: https://github.com/perlun/perlang/issues/82
+      - .github/workflows/publish-packages.yml
       - Perlang**
 
 jobs:
@@ -48,14 +47,17 @@ jobs:
       - name: Create linux-x64 .tar.gz file
         run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${GITHUB_SHA::9}-linux-x64.tar.gz *
         working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/publish
+        if: github.ref == 'ref/head/master'
 
       - name: Create osx-x64 .tar.gz file
         run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${GITHUB_SHA::9}-osx-x64.tar.gz *
         working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/osx-x64/publish
+        if: github.ref == 'ref/head/master'
 
       - name: Create win-x64 .tar.gz file
         run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${GITHUB_SHA::9}-win-x64.tar.gz *
         working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/publish
+        if: github.ref == 'ref/head/master'
 
       #
       # Upload files to releases server via rsync
@@ -69,6 +71,7 @@ jobs:
           REMOTE_HOST: ${{ secrets.SSH_REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
           TARGET: ${{ secrets.SSH_REMOTE_TARGET }}
+        if: github.ref == 'ref/head/master'
 
       - name: Upload osx-x64 .tar.gz file to build cloud
         uses: easingthemes/ssh-deploy@v2.1.1
@@ -79,6 +82,7 @@ jobs:
           REMOTE_HOST: ${{ secrets.SSH_REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
           TARGET: ${{ secrets.SSH_REMOTE_TARGET }}
+        if: github.ref == 'ref/head/master'
 
       - name: Upload win-x64 .tar.gz file to releases server
         uses: easingthemes/ssh-deploy@v2.1.1
@@ -89,6 +93,7 @@ jobs:
           REMOTE_HOST: ${{ secrets.SSH_REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.SSH_REMOTE_USER }}
           TARGET: ${{ secrets.SSH_REMOTE_TARGET }}
+        if: github.ref == 'ref/head/master'
 
       - name: Update latest build symlink
         uses: appleboy/ssh-action@v0.1.1
@@ -97,3 +102,4 @@ jobs:
           username: ${{ secrets.SSH_REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: ${{ secrets.UPDATE_SYMLINK_CMD }}
+        if: github.ref == 'ref/head/master'

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -7,6 +7,7 @@ on:
     paths:
       # TODO: Replace Perlang** with src/ once we have moved all the projects in there.
       # TODO: https://github.com/perlun/perlang/issues/82
+      - .github/workflows/publish-website.yml
       - docs/**
       - Perlang**
 


### PR DESCRIPTION
...but only upload the build if the ref is `ref/head/master`.

This aims to prevent things like https://github.com/perlun/perlang/commit/ed9205a043c137fb7138fef060dcf5d3d94f3c7b,
where we merge things into master which are broken, only to detect it _after_ it has been merged.

Also fixes the publish step. The problem was that we were building an individual `.csproj`, which means that `$(SolutionDir)` will not be what you'd expect it to be.