### PR TITLE
(ci) Set SolutionDir in publish-packages.yml

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -30,16 +30,13 @@ jobs:
       # Build releases
       #
       - name: Build linux-x64 release
-        run: dotnet publish -c Release -r linux-x64 --self-contained true /p:PublishReadyToRun=true
-        working-directory: ./Perlang.ConsoleApp
+        run: dotnet publish Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r linux-x64 --self-contained true /p:PublishReadyToRun=true /p:SolutionDir=$(pwd)/
 
       - name: Build osx-x64 release
-        run: dotnet publish -c Release -r osx-x64 --self-contained true
-        working-directory: ./Perlang.ConsoleApp
+        run: dotnet publish Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r osx-x64 --self-contained true /p:SolutionDir=$(pwd)/
 
       - name: Build win-x64 release
-        run: dotnet publish -c Release -r win-x64 --self-contained true
-        working-directory: ./Perlang.ConsoleApp
+        run: dotnet publish Perlang.ConsoleApp/Perlang.ConsoleApp.csproj -c Release -r win-x64 --self-contained true /p:SolutionDir=$(pwd)/
 
       #
       # Create .tar.gz archives


### PR DESCRIPTION
(Includes #90 until merged.)

This fixes the breakage introduced in https://github.com/perlun/perlang/commit/ed9205a043c137fb7138fef060dcf5d3d94f3c7b