### PR TITLE
(solution) Upgrade StyleCop to 1.2.0-beta.205

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="all" />
         <AdditionalFiles Include="$(SolutionDir)stylecop.json" Link="stylecop.json" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
There were some issues with SA1008 and statements like this that fueled the upgrade this time:

```c#
            // Trim the surrounding quotes.
            string value = source[(start + 1)..(current - 1)];
            AddToken(STRING, value);
```

StyleCop wanted to have a space between `.. (` which seemed rather odd. Upgrading seemed to fix this.