### PR TITLE
(parser) Enable TreatWarningsAsErrors

### DIFF
--- a/Perlang.Parser/ParseError.cs
+++ b/Perlang.Parser/ParseError.cs
@@ -7,8 +7,8 @@ namespace Perlang.Parser
         public Token Token { get; }
         public ParseErrorType? ParseErrorType { get; }
 
-        public ParseError(string message, Token token, ParseErrorType? errorType) :
-            base(message)
+        public ParseError(string message, Token token, ParseErrorType? errorType)
+            : base(message)
         {
             Token = token;
             ParseErrorType = errorType;

--- a/Perlang.Parser/Perlang.Parser.csproj
+++ b/Perlang.Parser/Perlang.Parser.csproj
@@ -8,10 +8,14 @@
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <DocumentationFile>bin\Debug\Perlang.Parser.xml</DocumentationFile>
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <DocumentationFile>bin\Release\Perlang.Parser.xml</DocumentationFile>
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      <NoWarn>1591;1701;1702</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Perlang.Parser/PerlangParser.cs
+++ b/Perlang.Parser/PerlangParser.cs
@@ -1,4 +1,11 @@
-﻿using System;
+// This class contains a number of these violations. While slightly ugly, it does make the code a bit more dense and
+// arguably, readable. I'm not fully convinced that adding the braces in this _particular case_ makes the code better.
+// Some form of switch expression-based solution would probably be good enough to convince me; feel free to give it a
+// try and send a PR.
+
+#pragma warning disable SA1503
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Perlang.TokenType;
@@ -175,12 +182,13 @@ namespace Perlang.Parser
                 });
             }
 
-            if (condition == null) condition = new Expr.Literal(true);
+            condition ??= new Expr.Literal(true);
+
             body = new Stmt.While(condition, body);
 
             if (initializer != null)
             {
-                body = new Stmt.Block(new List<Stmt> {initializer, body});
+                body = new Stmt.Block(new List<Stmt> { initializer, body });
             }
 
             return body;
@@ -279,7 +287,8 @@ namespace Perlang.Parser
 
             var methods = new List<Stmt.Function>();
 
-            while (!Check(RIGHT_BRACE) && !IsAtEnd()) {
+            while (!Check(RIGHT_BRACE) && !IsAtEnd())
+            {
                 methods.Add(Function("method"));
             }
 
@@ -314,7 +323,8 @@ namespace Perlang.Parser
                     }
 
                     parameters.Add(new Parameter(parameterName, new TypeReference(parameterTypeSpecifier)));
-                } while (Match(COMMA));
+                }
+                while (Match(COMMA));
             }
 
             Consume(RIGHT_PAREN, "Expect ')' after parameters.");
@@ -401,9 +411,9 @@ namespace Perlang.Parser
 
             while (Match(OR))
             {
-                Token _operator = Previous();
+                Token @operator = Previous();
                 Expr right = And();
-                expr = new Expr.Logical(expr, _operator, right);
+                expr = new Expr.Logical(expr, @operator, right);
             }
 
             return expr;
@@ -415,9 +425,9 @@ namespace Perlang.Parser
 
             while (Match(AND))
             {
-                Token _operator = Previous();
+                Token @operator = Previous();
                 Expr right = Equality();
-                expr = new Expr.Logical(expr, _operator, right);
+                expr = new Expr.Logical(expr, @operator, right);
             }
 
             return expr;
@@ -429,9 +439,9 @@ namespace Perlang.Parser
 
             while (Match(BANG_EQUAL, EQUAL_EQUAL))
             {
-                Token _operator = Previous();
+                Token @operator = Previous();
                 Expr right = Comparison();
-                expr = new Expr.Binary(expr, _operator, right);
+                expr = new Expr.Binary(expr, @operator, right);
             }
 
             return expr;
@@ -443,9 +453,9 @@ namespace Perlang.Parser
 
             while (Match(GREATER, GREATER_EQUAL, LESS, LESS_EQUAL))
             {
-                Token _operator = Previous();
+                Token @operator = Previous();
                 Expr right = Addition();
-                expr = new Expr.Binary(expr, _operator, right);
+                expr = new Expr.Binary(expr, @operator, right);
             }
 
             return expr;
@@ -457,9 +467,9 @@ namespace Perlang.Parser
 
             while (Match(MINUS, PLUS))
             {
-                Token _operator = Previous();
+                Token @operator = Previous();
                 Expr right = Multiplication();
-                expr = new Expr.Binary(expr, _operator, right);
+                expr = new Expr.Binary(expr, @operator, right);
             }
 
             return expr;
@@ -471,9 +481,9 @@ namespace Perlang.Parser
 
             while (Match(SLASH, STAR))
             {
-                Token _operator = Previous();
+                Token @operator = Previous();
                 Expr right = UnaryPrefix();
-                expr = new Expr.Binary(expr, _operator, right);
+                expr = new Expr.Binary(expr, @operator, right);
             }
 
             return expr;
@@ -483,9 +493,9 @@ namespace Perlang.Parser
         {
             if (Match(BANG, MINUS))
             {
-                Token _operator = Previous();
+                Token @operator = Previous();
                 Expr right = UnaryPrefix();
-                return new Expr.UnaryPrefix(_operator, right);
+                return new Expr.UnaryPrefix(@operator, right);
             }
 
             return Call();
@@ -529,7 +539,8 @@ namespace Perlang.Parser
                     }
 
                     arguments.Add(Expression());
-                } while (Match(COMMA));
+                }
+                while (Match(COMMA));
             }
 
             Token paren = Consume(RIGHT_PAREN, "Expect ')' after arguments.");
@@ -575,8 +586,8 @@ namespace Perlang.Parser
         ///
         /// For a non-consuming version of this, see <see cref="Check"/>.
         /// </summary>
-        /// <param name="types">One or more token types to match</param>
-        /// <returns>true if a matching token was found and consumed, false otherwise</returns>
+        /// <param name="types">One or more token types to match.</param>
+        /// <returns>`true` if a matching token was found and consumed, `false` otherwise.</returns>
         private bool Match(params TokenType[] types)
         {
             foreach (TokenType type in types)
@@ -592,14 +603,14 @@ namespace Perlang.Parser
         }
 
         /// <summary>
-        /// Matches the given token type at the current position. If the current token does not match, an exception is
-        /// thrown.
+        /// Matches the given token type at the current position, expecting a match. If the current token does not
+        /// match, an exception is thrown.
         /// </summary>
-        /// <param name="type">the type of token to match</param>
-        /// <param name="message">the error message to use if the token does not match</param>
-        /// <param name="parseErrorType">an optional parameter indicating the type of parse error</param>
-        /// <returns>the matched token</returns>
-        /// <exception cref="ParseError">if the token does not match</exception>
+        /// <param name="type">The type of token to match.</param>
+        /// <param name="message">The error message to use if the token does not match.</param>
+        /// <param name="parseErrorType">An optional parameter indicating the type of parse error.</param>
+        /// <returns>The matched token.</returns>
+        /// <exception cref="ParseError">The token does not match.</exception>
         private Token Consume(TokenType type, string message, ParseErrorType? parseErrorType = null)
         {
             if (Check(type))
@@ -611,11 +622,11 @@ namespace Perlang.Parser
         }
 
         /// <summary>
-        /// Checks if the current token matches the provided TokenType. Similar to <see cref="Match"/> but does not
-        /// consume the token on matches.
+        /// Non-consuming version of <see cref="Match"/>: checks if the current token matches the provided <see
+        /// cref="TokenType"/>, but does not consume the token even if it matches.
         /// </summary>
-        /// <param name="type">the TokenType to match</param>
-        /// <returns>true if it matches, false otherwise</returns>
+        /// <param name="type">The `TokenType` to match.</param>
+        /// <returns>`true` if it matches, `false` otherwise.</returns>
         private bool Check(TokenType type)
         {
             if (IsAtEnd())
@@ -644,7 +655,7 @@ namespace Perlang.Parser
         /// <summary>
         /// Returns the token at the current position.
         /// </summary>
-        /// <returns>A Token</returns>
+        /// <returns>A token.</returns>
         private Token Peek()
         {
             return tokens[current];
@@ -653,7 +664,7 @@ namespace Perlang.Parser
         /// <summary>
         /// Returns the token right before the current position.
         /// </summary>
-        /// <returns>A Token</returns>
+        /// <returns>A token.</returns>
         private Token Previous()
         {
             return tokens[current - 1];

--- a/Perlang.Parser/ScanError.cs
+++ b/Perlang.Parser/ScanError.cs
@@ -6,8 +6,8 @@ namespace Perlang.Parser
     {
         public int Line { get; }
 
-        public ScanError(string message, int line) :
-            base(message)
+        public ScanError(string message, int line)
+            : base(message)
         {
             Line = line;
         }

--- a/Perlang.Parser/Scanner.cs
+++ b/Perlang.Parser/Scanner.cs
@@ -9,22 +9,22 @@ namespace Perlang.Parser
         public static readonly IDictionary<string, TokenType> ReservedKeywords =
             new Dictionary<string, TokenType>
             {
-                {"and", AND},
-                {"class", CLASS},
-                {"else", ELSE},
-                {"false", FALSE},
-                {"for", FOR},
-                {"fun", FUN},
-                {"if", IF},
-                {"nil", NIL},
-                {"or", OR},
-                {"print", PRINT},
-                {"return", RETURN},
-                {"super", SUPER},
-                {"this", THIS},
-                {"true", TRUE},
-                {"var", VAR},
-                {"while", WHILE}
+                { "and", AND },
+                { "class", CLASS },
+                { "else", ELSE },
+                { "false", FALSE },
+                { "for", FOR },
+                { "fun", FUN },
+                { "if", IF },
+                { "nil", NIL },
+                { "or", OR },
+                { "print", PRINT },
+                { "return", RETURN },
+                { "super", SUPER },
+                { "this", THIS },
+                { "true", TRUE },
+                { "var", VAR },
+                { "while", WHILE }
             };
 
         private readonly string source;
@@ -50,7 +50,7 @@ namespace Perlang.Parser
                 ScanToken();
             }
 
-            tokens.Add(new Token(EOF, "", null, line));
+            tokens.Add(new Token(EOF, System.String.Empty, null, line));
             return tokens;
         }
 
@@ -109,8 +109,11 @@ namespace Perlang.Parser
                 case '/':
                     if (Match('/'))
                     {
-                        // A comment goes until the end of the line.
-                        while (Peek() != '\n' && !IsAtEnd()) Advance();
+                        // A comment continues until the end of the line.
+                        while (Peek() != '\n' && !IsAtEnd())
+                        {
+                            Advance();
+                        }
                     }
                     else
                     {
@@ -153,7 +156,10 @@ namespace Perlang.Parser
 
         private void Identifier()
         {
-            while (IsAlphaNumeric(Peek())) Advance();
+            while (IsAlphaNumeric(Peek()))
+            {
+                Advance();
+            }
 
             // See if the identifier is a reserved word.
             string text = source[start..current];
@@ -166,7 +172,10 @@ namespace Perlang.Parser
         {
             bool isFractional = false;
 
-            while (IsDigit(Peek())) Advance();
+            while (IsDigit(Peek()))
+            {
+                Advance();
+            }
 
             // Look for a fractional part.
             if (Peek() == '.' && IsDigit(PeekNext()))
@@ -176,7 +185,10 @@ namespace Perlang.Parser
                 // Consume the "."
                 Advance();
 
-                while (IsDigit(Peek())) Advance();
+                while (IsDigit(Peek()))
+                {
+                    Advance();
+                }
             }
 
             if (isFractional)
@@ -193,15 +205,15 @@ namespace Perlang.Parser
 
                 if (value < Int32.MaxValue)
                 {
-                    AddToken(NUMBER, (int)value);
+                    AddToken(NUMBER, (int) value);
                 }
                 else if (value < UInt32.MaxValue)
                 {
-                    AddToken(NUMBER, (uint)value);
+                    AddToken(NUMBER, (uint) value);
                 }
                 else if (value < Int64.MaxValue)
                 {
-                    AddToken(NUMBER, (long)value);
+                    AddToken(NUMBER, (long) value);
                 }
                 else // ulong
                 {
@@ -214,7 +226,11 @@ namespace Perlang.Parser
         {
             while (Peek() != '"' && !IsAtEnd())
             {
-                if (Peek() == '\n') line++;
+                if (Peek() == '\n')
+                {
+                    line++;
+                }
+
                 Advance();
             }
 

--- a/Perlang.sln.DotSettings
+++ b/Perlang.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_WHILE_ON_NEW_LINE/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CustomTools/CustomToolsData/@EntryValue"></s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -7,6 +7,10 @@
         <Rule Id="SA1003" Action="None"/>       <!-- Symbols should be spaced correctly -->
         <Rule Id="SA1009" Action="None"/>       <!-- Closing parenthesis should be spaced correctly -->
         <Rule Id="SA1101" Action="None"/>       <!-- Prefix local calls with this -->
+
+        <!-- This one mostly makes sense, _but_ it can at the same time be useful to document the "else // condition-here". -->
+        <Rule Id="SA1108" Action="None"/>       <!-- Block statements should not contain embedded comments -->
+
         <Rule Id="SA1111" Action="None"/>       <!-- Closing parenthesis should be on line of last parameter -->
         <Rule Id="SA1120" Action="None"/>       <!-- Comments should contain text -->
         <Rule Id="SA1121" Action="None"/>       <!-- Use built-in type alias -->


### PR DESCRIPTION
Again, more follow-up work related to #35.

This should be the last one in these series. Once this is merged, all projects have `TreatWarningsAsErrors` enabled. :tada: 