### PR TITLE
(many) Support statements without semicolon in REPL mode

### DIFF
--- a/Perlang.ConsoleApp/Program.cs
+++ b/Perlang.ConsoleApp/Program.cs
@@ -86,7 +86,12 @@ namespace Perlang.ConsoleApp
             // TODO: Make it possible to override this at some point, so the caller can separate between these types of output.
             this.standardErrorHandler = standardOutputHandler ?? Console.Error.WriteLine;
 
-            interpreter = new PerlangInterpreter(runtimeErrorHandler: runtimeErrorHandler ?? RuntimeError, this.standardOutputHandler, arguments ?? new List<string>());
+            interpreter = new PerlangInterpreter(
+                runtimeErrorHandler: runtimeErrorHandler ?? RuntimeError,
+                this.standardOutputHandler,
+                arguments ?? new List<string>(),
+                replMode: true
+            );
         }
 
         private void RunFile(string path)

--- a/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -17,7 +17,7 @@ namespace Perlang.Tests.ConsoleApp
         }
 
         [Fact]
-        public void Run_can_run_multiple_statements_separated_by_semicolon()
+        public void Run_supports_multiple_statements_separated_by_semicolon()
         {
             subject.Run("var a = 42; print a;");
 
@@ -25,12 +25,28 @@ namespace Perlang.Tests.ConsoleApp
         }
 
         [Fact]
+        public void Run_supports_final_semicolon_elision_single_statement()
+        {
+            subject.Run("print 10");
+
+            Assert.Equal(new List<string> { "10" }, output);
+        }
+
+        [Fact]
+        public void Run_supports_final_semicolon_elision_multiple_statements()
+        {
+            subject.Run("var a = 43; print a");
+
+            Assert.Equal(new List<string> { "43" }, output);
+        }
+
+        [Fact]
         public void Run_state_persists_between_invocations()
         {
-            subject.Run("var a = 42;");
+            subject.Run("var a = 44;");
             subject.Run("print a;");
 
-            Assert.Equal(new List<string> { "42" }, output);
+            Assert.Equal(new List<string> { "44" }, output);
         }
 
         [Fact]


### PR DESCRIPTION
This turned out to be quite easy. Tests have been added to verify the new functionality.

Closes #100.