### PR TITLE
(many) De-deduplicate InformationalVersion

### DIFF
--- a/Perlang.Common/CommonConstants.cs
+++ b/Perlang.Common/CommonConstants.cs
@@ -15,6 +15,7 @@ namespace Perlang
     public static partial class CommonConstants
     {
         public const string Version = "0.1.0";
+        public const string InformationalVersion = Version + "+" + GitVersion;
 
         public static string GetFullVersion() =>
             ((AssemblyInformationalVersionAttribute)Assembly

--- a/Perlang.Common/Properties/AssemblyInfo.cs
+++ b/Perlang.Common/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@ using System.Reflection;
 using Perlang;
 
 [assembly: AssemblyVersion(CommonConstants.Version)]
-[assembly: AssemblyInformationalVersion(CommonConstants.Version + "+" + CommonConstants.GitVersion)]
+[assembly: AssemblyInformationalVersion(CommonConstants.InformationalVersion)]

--- a/Perlang.ConsoleApp/Properties/AssemblyInfo.cs
+++ b/Perlang.ConsoleApp/Properties/AssemblyInfo.cs
@@ -3,5 +3,5 @@ using System.Runtime.CompilerServices;
 using Perlang;
 
 [assembly: AssemblyVersion(CommonConstants.Version)]
-[assembly: AssemblyInformationalVersion(CommonConstants.Version + "+" + CommonConstants.GitVersion)]
+[assembly: AssemblyInformationalVersion(CommonConstants.InformationalVersion)]
 [assembly: InternalsVisibleTo("Perlang.Tests")]

--- a/Perlang.Parser/Properties/AssemblyInfo.cs
+++ b/Perlang.Parser/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@ using System.Reflection;
 using Perlang;
 
 [assembly: AssemblyVersion(CommonConstants.Version)]
-[assembly: AssemblyInformationalVersion(CommonConstants.Version + "+" + CommonConstants.GitVersion)]
+[assembly: AssemblyInformationalVersion(CommonConstants.InformationalVersion)]

--- a/Perlang.Stdlib/Properties/AssemblyInfo.cs
+++ b/Perlang.Stdlib/Properties/AssemblyInfo.cs
@@ -2,4 +2,4 @@ using System.Reflection;
 using Perlang;
 
 [assembly: AssemblyVersion(CommonConstants.Version)]
-[assembly: AssemblyInformationalVersion(CommonConstants.Version + "+" + CommonConstants.GitVersion)]
+[assembly: AssemblyInformationalVersion(CommonConstants.InformationalVersion)]


### PR DESCRIPTION
This is a preparational commit before moving over these to proper SemVer values, indicating that non-tagged versions are snapshot builds.