### PR TITLE
(many) Make --version indicate pre-releases in a SemVer-compliant way

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -42,17 +42,17 @@ jobs:
       # Create .tar.gz archives
       #
       - name: Create linux-x64 .tar.gz file
-        run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${GITHUB_SHA::9}-linux-x64.tar.gz *
+        run: tar cvzf ../perlang-$(./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/perlang -v)-linux-x64.tar.gz *
         working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/publish
         if: github.ref == 'refs/heads/master'
 
       - name: Create osx-x64 .tar.gz file
-        run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${GITHUB_SHA::9}-osx-x64.tar.gz *
+        run: tar cvzf ../perlang-$(./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/perlang -v)-osx-x64.tar.gz *
         working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/osx-x64/publish
         if: github.ref == 'refs/heads/master'
 
       - name: Create win-x64 .tar.gz file
-        run: tar cvzf ../perlang-${{steps.timestamp.outputs.timestamp}}-${GITHUB_SHA::9}-win-x64.tar.gz *
+        run: tar cvzf ../perlang-$(./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/perlang -v)-win-x64.tar.gz *
         working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/publish
         if: github.ref == 'refs/heads/master'
 

--- a/Perlang.Common/CommonConstants.cs
+++ b/Perlang.Common/CommonConstants.cs
@@ -14,8 +14,8 @@ namespace Perlang
     /// </summary>
     public static partial class CommonConstants
     {
-        public const string Version = "0.1.0";
-        public const string InformationalVersion = Version + "+" + GitVersion;
+        public const string Version = GitTagVersion;
+        public const string InformationalVersion = GitDescribeVersion;
 
         public static string GetFullVersion() =>
             ((AssemblyInformationalVersionAttribute)Assembly

--- a/Perlang.ConsoleApp/Program.cs
+++ b/Perlang.ConsoleApp/Program.cs
@@ -38,6 +38,18 @@ namespace Perlang.ConsoleApp
         /// <returns>Zero if the program executed successfully; non-zero otherwise.</returns>
         public static int Main(string[] args)
         {
+            return MainWithCustomConsole(args, console: null);
+        }
+
+        /// <summary>
+        /// Entry point for `perlang`, with the possibility to override the console streams (stdin, stdout, stderr).
+        /// </summary>
+        /// <param name="args">The command line arguments.</param>
+        /// <param name="console">A custom `IConsole` implementation to use. May be null, in which case the standard
+        /// streams of the calling process will be used.</param>
+        /// <returns>Zero if the program executed successfully; non-zero otherwise.</returns>
+        public static int MainWithCustomConsole(string[] args, IConsole console)
+        {
             var versionOption = new Option(new[] { "--version", "-v" }, "Show version information");
 
             var rootCommand = new RootCommand
@@ -90,7 +102,7 @@ namespace Perlang.ConsoleApp
             return new CommandLineBuilder(rootCommand)
                 .UseDefaults()
                 .Build()
-                .Invoke(args);
+                .Invoke(args, console);
         }
 
         internal Program(
@@ -104,7 +116,7 @@ namespace Perlang.ConsoleApp
             this.standardErrorHandler = standardOutputHandler ?? Console.Error.WriteLine;
 
             interpreter = new PerlangInterpreter(
-                runtimeErrorHandler: runtimeErrorHandler ?? RuntimeError,
+                runtimeErrorHandler ?? RuntimeError,
                 this.standardOutputHandler,
                 arguments ?? new List<string>(),
                 replMode: true
@@ -166,7 +178,7 @@ namespace Perlang.ConsoleApp
 
         private void PrintBanner()
         {
-            standardOutputHandler($"Perlang Interactive REPL Console ({CommonConstants.GetFullVersion()})");
+            standardOutputHandler($"Perlang Interactive REPL Console ({CommonConstants.GetFullVersion()}, built from {CommonConstants.GitRevision})");
         }
 
         private void ScanError(ScanError scanError)

--- a/Perlang.Tests/ConsoleApp/ProgramTest.cs
+++ b/Perlang.Tests/ConsoleApp/ProgramTest.cs
@@ -1,6 +1,7 @@
 #pragma warning disable S3626
 
 using System.Collections.Generic;
+using System.CommandLine.IO;
 using Perlang.ConsoleApp;
 using Xunit;
 
@@ -75,14 +76,25 @@ namespace Perlang.Tests.ConsoleApp
         }
 
         [Fact]
-        public void Run_last_variable_defined_with_a_given_name_takes_precedence()
+        public void Run_variable_redefined_throws_expected_error()
         {
-            // This is definitely a bug. The second statement should cause an error, since a global variable with the
-            // same name already exists. For now, this test will remember us that these are the currently expected
-            // semantics.
+            // Act
             subject.Run("var a = 42;");
+
+            // Assert
             var exception = Assert.Throws<RuntimeError>(() => subject.Run("var a = 44;"));
             Assert.Matches("Variable with this name already declared in this scope", exception.Message);
+        }
+
+        [Fact]
+        public void Run_with_version_parameter_outputs_expected_value()
+        {
+            // Arrange & Act
+            var testConsole = new TestConsole();
+            Program.MainWithCustomConsole(new[] { "--version" }, testConsole);
+
+            // Assert
+            Assert.Equal(CommonConstants.InformationalVersion + "\n", testConsole.Out.ToString());
         }
     }
 }

--- a/Perlang.Tests/Perlang.Tests.csproj
+++ b/Perlang.Tests/Perlang.Tests.csproj
@@ -2,9 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <IsPackable>false</IsPackable>
-
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/Perlang.Tests/Properties/AssemblyInfo.cs
+++ b/Perlang.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,5 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Perlang;
 
 [assembly: AssemblyVersion(CommonConstants.Version)]
 [assembly: AssemblyInformationalVersion(CommonConstants.InformationalVersion)]
-[assembly: InternalsVisibleTo("Perlang.Tests")]

--- a/scripts/update_common_constants.rb
+++ b/scripts/update_common_constants.rb
@@ -2,7 +2,12 @@
 
 SOLUTION_DIR = ARGV.pop or abort('Error: Solution directory must be provided')
 
-GIT_VERSION = `git describe --always`.rstrip
+# Need to take -dev part out of e.g. 1.0.0-dev, since assembly versions must
+# adhere to the following format: major[.minor[.build[.revision]]]
+GIT_TAG_VERSION = `git describe --tags --abbrev=0 | sed s/-dev//`.rstrip
+
+GIT_DESCRIBE_VERSION = `git describe --tags | sed s/-g.*$// | sed s/dev-/dev./`.rstrip
+GIT_REVISION = `git describe --always`.rstrip
 
 common_constants = <<~EOF
 //
@@ -12,7 +17,9 @@ namespace Perlang
 {
     public static partial class CommonConstants
     {
-        public const string GitVersion = "#{GIT_VERSION}";
+        public const string GitTagVersion = "#{GIT_TAG_VERSION}";
+        public const string GitDescribeVersion = "#{GIT_DESCRIBE_VERSION}";
+        public const string GitRevision = "#{GIT_REVISION}";
     }
 }
 EOF


### PR DESCRIPTION
Not fully happy with the weird semantics in the `ProgramTest` test method I added, but apart from that, it should be good to go. Might look one more time at that before merging it.