### PR TITLE
(consoleapp) Support shorthand -v flag (for --version)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ SHELL=/bin/bash -e -o pipefail
 all: auto-generated
 	dotnet build
 
-auto-generated:
+auto-generated: Perlang.Common/CommonConstants.Generated.cs
+
+# Technically untrue, since this should be regenerated every time the git HEAD
+# is updated. But it's only critical that this is 100% correct in CI, where we
+# actually create builds that will be deployed to someone else's machine. (I
+# might have to eat this up someday. :-)
+Perlang.Common/CommonConstants.Generated.cs: ./scripts/update_common_constants.rb
 	./scripts/update_common_constants.rb `pwd`
 
 clean:


### PR DESCRIPTION
While working on #106, I figured out a way to support this. This essentially also overrides the automatically provided
`System.CommandLine`-implementation for this option, which was required for fixing a failing unit test in #106.