### PR TITLE
(ci) Fix publish-packages .tar.gz file names

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -8,16 +8,17 @@ on:
       - .github/workflows/publish-packages.yml
       - Perlang**
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail -O inherit_errexit {0}
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get current timestamp
-        id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y%m%d%H%M%S')"
-
       - uses: actions/checkout@v1
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
@@ -42,19 +43,19 @@ jobs:
       # Create .tar.gz archives
       #
       - name: Create linux-x64 .tar.gz file
-        run: tar cvzf ../perlang-$(./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/perlang -v)-linux-x64.tar.gz *
-        working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/publish
-        if: github.ref == 'refs/heads/master'
+        run: version=$(../../linux-x64/perlang -v) && tar cvzf ../perlang-$version-linux-x64.tar.gz *
+        working-directory: Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/publish
 
       - name: Create osx-x64 .tar.gz file
-        run: tar cvzf ../perlang-$(./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/perlang -v)-osx-x64.tar.gz *
-        working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/osx-x64/publish
-        if: github.ref == 'refs/heads/master'
+        run: version=$(../../linux-x64/perlang -v) && tar cvzf ../perlang-$version-osx-x64.tar.gz *
+        working-directory: Perlang.ConsoleApp/bin/Release/netcoreapp3.1/osx-x64/publish
 
       - name: Create win-x64 .tar.gz file
-        run: tar cvzf ../perlang-$(./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/linux-x64/perlang -v)-win-x64.tar.gz *
-        working-directory: ./Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/publish
-        if: github.ref == 'refs/heads/master'
+        run: version=$(../../linux-x64/perlang -v) && tar cvzf ../perlang-$version-win-x64.tar.gz *
+        working-directory: Perlang.ConsoleApp/bin/Release/netcoreapp3.1/win-x64/publish
+
+      - name: List .tar.gz files
+        run: ls -l Perlang.ConsoleApp/bin/Release/netcoreapp3.1/*/*.tar.gz
 
       #
       # Upload files to releases server via rsync


### PR DESCRIPTION
This fixes a regression in #106 - we tried to make the file names more nicely looking, but failed. The error handling wasn't helpful to prevent that mistake from happening, so this PR tries to improve in that area as well - trying more stricly to follow the _fail fast_ philosophy.