### PR TITLE
(parser) Support shebang lines

### DIFF
--- a/Perlang.Tests.Integration/Shebang.cs
+++ b/Perlang.Tests.Integration/Shebang.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using Perlang.Parser;
+using Xunit;
+using static Perlang.Tests.Integration.EvalHelper;
+
+namespace Perlang.Tests.Integration
+{
+    public class Shebang
+    {
+        [Fact]
+        public void initial_shebang_is_silently_ignored()
+        {
+            string source = @"
+                #!/usr/bin/env perlang
+                print 24219;
+            ".Trim();
+
+            string output = EvalReturningOutput(source).SingleOrDefault();
+
+            Assert.Equal("24219", output);
+        }
+
+        [Fact]
+        public void shebang_in_the_middle_of_program_throws_expected_error()
+        {
+            string source = @"
+                var a = 10;
+                #!/usr/bin/env perlang
+                var b = 10;
+            ".Trim();
+
+            Assert.Throws<ScanError>(() => EvalReturningOutput(source).SingleOrDefault());
+        }
+    }
+}


### PR DESCRIPTION
Implementing this in the scanner was simplest. Note that the following constraints apply:

- The shebang can only be placed at the very first line of the program. Any other placements will end up in a `ScanError`. There can also be no preceding whitespace before the shebang; I believe this is how `bash` and other POSIX shells do it as well.
- The shebang is not "parsed" in any way. In other words, writing `#!/usr/bin/env perlang arg1 arg2` will **not** cause `arg1` and `arg2` to be passed to the program.

Fixes #21.